### PR TITLE
Sample genres first, then tracks

### DIFF
--- a/src/data/data.json
+++ b/src/data/data.json
@@ -58,2966 +58,2488 @@
     "Jump Up",
     "Trip Hop"
   ],
-  "tracks": [
-    {
-      "ytId": "8rXD2Vnll0E",
-      "title": "Eddie Richards ‎- Be Still",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "yGSO6cZ36XU",
-      "title": "Octave One - I Believe",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "infb1G4nD5s",
-      "title": "Colin Dale - You Know How (Mothersole & Freemans 'Freesole Dub')",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "ulncNi-acYo",
-      "title": "Laurent Wolf feat Well Talmer - Together",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "l3rJqLFswnY",
-      "title": "Blake Baxter - Get Layed",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "rjYmzjjNf6w",
-      "title": "Terry Francis - Loving you",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "8BTUfA4kNlg",
-      "title": "Gene Farris - Move Your Body",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "vonZzW0rv34",
-      "title": "Jay Tripwire - How We Used To Do It",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "K5ZKlFhcRoA",
-      "title": "Housey Doingz - Lounge",
-      "genre": "tech house"
-    },
-    {
-      "ytId": "6_CZoM72ITo",
-      "title": "Amine Edge & DANCE - Halfway Crooks",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "PgpnWJu7rog",
-      "title": "Destructo - Party Up ft. YG",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "s-nrvyOTDIc",
-      "title": "DJ Deeon - Let Me Bang",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "1txVyyLkb6g",
-      "title": "Shiba San - OKAY",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "Gk88dljeg6E",
-      "title": "Jammin Gerald - Pump That Shit Up",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "XzxIHXZdDc0",
-      "title": "DJ Godfather - Player Haters in Dis House",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "8Pnd2JDoX9g",
-      "title": "Disco D - You Need Another Drink",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "aHiPaL0MTUk",
-      "title": "DJ ASSAULT - Raccoon",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "UdNEASBplDs",
-      "title": "DJ Chip - hold up wait a minute",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "ouMTwFpZNso",
-      "title": "DJ Rashad - Drop Juke Out",
-      "genre": "Ghetto House"
-    },
-    {
-      "ytId": "D8K90hX4PrE",
-      "title": "Daft Punk - Technologic",
-      "genre": "French House"
-    },
-    {
-      "ytId": "Yu0f7Tj_PaI",
-      "title": "Cassius - 1999",
-      "genre": "French House"
-    },
-    {
-      "ytId": "Wn_Mt3agjos",
-      "title": "Etienne de Crecy & Alex Gopher - Overnet",
-      "genre": "French House"
-    },
-    {
-      "ytId": "yatShLljhlo",
-      "title": "Armand Van Helden - Into Your Eyes",
-      "genre": "French House"
-    },
-    {
-      "ytId": "4p_WxAA-OcQ",
-      "title": "Laurent Garnier - Man with the red face",
-      "genre": "French House"
-    },
-    {
-      "ytId": "qmsbP13xu6k",
-      "title": "Mr Oizo - Flat beat",
-      "genre": "French House"
-    },
-    {
-      "ytId": "TUC2b-OSZ00",
-      "title": "Stardust - Music Sounds Better With You",
-      "genre": "French House"
-    },
-    {
-      "ytId": "YCRu4zFLYxo",
-      "title": "Roger Sanchez - Another Chance",
-      "genre": "French House"
-    },
-    {
-      "ytId": "3J0j5QDJkGA",
-      "title": "Freemasons feat. Siedah Garrett - Rain Down Love",
-      "genre": "French House"
-    },
-    {
-      "ytId": "5rAOyh7YmEc",
-      "title": "Basement Jaxx - Where's Your Head At",
-      "genre": "French House"
-    },
-    {
-      "ytId": "dH8WvayAo1M",
-      "title": "Mousse T. feat. Hot 'n' Juicy - Horny '98",
-      "genre": "French House"
-    },
-    {
-      "ytId": "jtQ-3Pua2Ms",
-      "title": "Akufen - Architextures 1",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "h0i1Szq6GM8",
-      "title": "Ricardo Villalobos - Dexter",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "O53-C8fMXhI",
-      "title": "Luomo - Tessio",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "uRJRjJuwZd0",
-      "title": "Farben - Swinn Off",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "c0Nu1qwT8os",
-      "title": "Matthew Dear- Deserter",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "UDyTfFPBAf4",
-      "title": "D.Diggler - Signals",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "lCIEI8Bg5Aw",
-      "title": "Benjamin Wild - Anschlusstreffer",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "v2VpuQwy3DI",
-      "title": "Isolée - Floripa",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "0J72ImA38nE",
-      "title": "John Tejada - The End Of It All",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "Pb2o__S9K6s",
-      "title": "Mosca - Clinical Trial",
-      "genre": "Minimal House"
-    },
-    {
-      "ytId": "LOLE1YE_oFQ",
-      "title": "Frankie Knuckles - Your Love",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "ts8iBs3tpmw",
-      "title": "Larry Heard a.k.a. Mr. Fingers - Can You Feel It?",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "QAR8cq5Bl94",
-      "title": "Marshall Jefferson - move your body",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "wI1rPWlgFxg",
-      "title": "Farley 'Jackmaster' Funk - Love Can't Turn Around",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "qUeMFG4wjJw",
-      "title": "Jesse Saunders - On and On",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "ZaHUK5GnDgE",
-      "title": "STEVE \"SILK\" HURLEY - Jack Your Body",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "dnvf0mwIIoY",
-      "title": "Kariya - Let Me Love You For Tonight",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "Yz1xMiyrfsw",
-      "title": "Joe Smooth - Promised Land (Club Mix)",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "U1i5GiE17mw",
-      "title": "Esther Williams - I'll Be Your Pleasure (Larry Levan Mix)",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "r_aFDMG6vWQ",
-      "title": "The 28th Street Crew - I Need A Rhythm",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "Dzy4YlwkJVI",
-      "title": "TC - 1991",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "EbfqyPvfP-4",
-      "title": "Mr Lee - Come To House",
-      "genre": "Chicago/Garage House"
-    },
-    {
-      "ytId": "LOnWVi8mOeY",
-      "title": "Frank Kvitta - Reinsteckefuchs",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "JtUv1yUsT68",
-      "title": "Weichentechnikk & Waldhaus - Es gibt kein Battle",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "l0Zl-Baw48w",
-      "title": "KillSwitch & Reset - Gazowany",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "2A8sVbz0uU4",
-      "title": "Greg Notill - Transcendance",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "pYX_GIpcTIE",
-      "title": "DJ Amok - Nightmare",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "vODHo5omPog",
-      "title": "dj rush my palazzo",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "4AzA7zjtSao",
-      "title": "Arkus P Hexen Process",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "iDVYFaiLEoM",
-      "title": "Jan Fleck - Come Get Some",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "L7ap4o_zYJo",
-      "title": "Felix Kröcher - Travel Pussy (Dont stop popp that Pussy)",
-      "genre": "Hardtechno"
-    },
-    {
-      "ytId": "kIC0aQ56ASE",
-      "title": "The Shapeshifters - Lola's Theme",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "4H5I6y1Qvz0",
-      "title": "Scissor Sisters - I Don't Feel Like Dancin'",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "sy1dYFGkPUE",
-      "title": "Justice - D.A.N.C.E.",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "KZoVM_ZfdY8",
-      "title": "Dimitri From Paris - Not Quite Disco",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "cOIIbxEtebg",
-      "title": "Lindstrøm - Closing Shot",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "L_fCqg92qks",
-      "title": "Eric Prydz - Call On Me",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "I2dfGC1oziE",
-      "title": "VITALIC - Poison Lips",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "N3kkNfH4yco",
-      "title": "Michael Gray - The Weekend",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "7BurNCK5Pc8",
-      "title": "Chromeo - Come Alive (feat. Toro y Moi)",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "xPrgVald-fc",
-      "title": "Big Gigantic- Sky High",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "p1JWpidoxSo",
-      "title": "This Moment- French Horn Rebellion",
-      "genre": "Nu Disco"
-    },
-    {
-      "ytId": "CUmze7jPiHA",
-      "title": "Sash! - Stay",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "y6120QOlsfU",
-      "title": "Darude - Sandstorm",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "wD0Mm6WIcYs",
-      "title": "Gigi D'Agostino - L'Amour Toujours",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "IksRDCMYnn8",
-      "title": "Safri Duo - Played-A-Live",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "X5S76oKO6NM",
-      "title": "Silence - Delirium ft Sarah Mclachlan",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "MxwSbZMDhK8",
-      "title": "Ian van Dahl - Castles In The Sky ",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "RK-PAzu1Tmw",
-      "title": "Tina Cousins - Pray",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "BF5bV6oWXJg",
-      "title": "Lasgo - Something   ",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "FA39yqwnX98",
-      "title": "Aurora ft. Naimee Coleman - Ordinary World",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "ReqPNqp8v14",
-      "title": "Paul Van Dyk - Nothing But You",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "uqEAD652ZS4",
-      "title": "The Mackenzie ft. Jessy - Innocence",
-      "genre": "Eurotrance"
-    },
-    {
-      "ytId": "SDAm9WRomzU",
-      "title": "cm - dream universe",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "vYO8jVDdpns",
-      "title": "Sasha - Xpander",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "5WF-wqlz7_s",
-      "title": "Blue alphabet - Yellow evolution",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "OFgQz7oZc_I",
-      "title": "BT - Nocturnal Transmission",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "V4K78rzxOTc",
-      "title": "Moogwai - Viola",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "ASh7z6eQUss",
-      "title": "T2 - 8-15 To Nowhere (DJ Taucher Remix)",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "vB6rrwwqaXA",
-      "title": "Albion - Air",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "kd9di4wp4g4",
-      "title": "Talla 2XLC Calls Moguai - Into Another (Moguai Clubmix)",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "whz-_ZigUDc",
-      "title": "Lost Tribe - Gamemaster",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "Rce8QnuFRVk",
-      "title": "PPK - Resurrection",
-      "genre": "Progressive Trance"
-    },
-    {
-      "ytId": "yxWzoYQb5gU",
-      "title": "Juan Atkins - Techno City",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "sMq90UAg-Zw",
-      "title": "Derrick May - The Dance",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "MV1B9S5Q6Bs",
-      "title": "Kevin Saunderson - Bassline",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "8AQ193-u4Q8",
-      "title": "A Number Of Names - Sharevari ",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "cZFL2Ewo-oI",
-      "title": "Cybotron - Techno City (Instrumental)",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "aPlRBcYC45Q",
-      "title": "Mad Mike - Hi-Tech Dreams",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "HBbpxesIAHs",
-      "title": "Claude Young - Impolite To Refuse",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "GwDuWU81-R8",
-      "title": "Rhythm Is Rhythm - Nude Photo",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "j04_zmENtv8",
-      "title": "Anthony \"Shake\" Shakir - Soundblaster",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "4WLtJDKXMCE",
-      "title": "Underground Resistance - The Final Frontier",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "KevUFO2moZI",
-      "title": "Jeff Mills - The Bells",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "0Mr0uNxXuIg",
-      "title": "Model 600 - Update (Version U.R.)",
-      "genre": "Detroit Techno"
-    },
-    {
-      "ytId": "t64m5Lm7CrA",
-      "title": "Trentemoller - Moan (Trentemoller Remix)",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "Pe18N8U87YU",
-      "title": "Gui Boratto - No turning back",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "b5zzS40-xbo",
-      "title": "James Holden - A Break In The Clouds",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "d7zBePUZMog",
-      "title": "Nathan Fake - The Sky was Pink",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "sdl7PZmlGQI",
-      "title": "Extrawelt - Soopertrack Original",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "qaQKvA94GUo",
-      "title": "Dominik Eulberg - Der Tanz der Gluehwuermchen",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "lQYfEpk9qMs",
-      "title": "Microtrauma - Diffusion",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "lZHHmyFhp6M",
-      "title": "Popof- Serenity",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "i77327EiOqg",
-      "title": "Shiva Chandra - Pieces",
-      "genre": "Neo-Trance"
-    },
-    {
-      "ytId": "J9yDoYRRBYY",
-      "title": "JX - Son of a Gun",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "g8k0dbPLT3w",
-      "title": "X-Cabs - Neuro",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "vtNv-pprhQ8",
-      "title": "FELIX - Don't You Want Me",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "lb8nCaFF5yM",
-      "title": "Blu Peter - Magic",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "b7xLMRbfxkk",
-      "title": "Commander Tom - Are Am Eye",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "tz3OJMYwQBg",
-      "title": "EMBARGO! - EMBARGO!",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "LTGxcO8C38Q",
-      "title": "Steve Thomas - Higher",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "CYXAKmAXHzA",
-      "title": "Robert Armani - Hit Hard",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "xdw4d12T_fU",
-      "title": "PUBLIC DOMAIN - Operation Blade (Bass In The Place...)",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "QQT6uCBYa68",
-      "title": "Klubbheads - Hiphopping",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "Mu0cE9RgK5M",
-      "title": "Dj Jean - The Launch",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "sVOVWwQlCNw",
-      "title": "Porn kings - Up To No Good",
-      "genre": "Hi-NRG"
-    },
-    {
-      "ytId": "ymNFyxvIdaM",
-      "title": "Bomfunk MC's - Freestyler",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "loOg5mIGHLY",
-      "title": "FLYING STEPS - Breakin' it Down",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "m4EtLOvwW5w",
-      "title": "Music Instructor - Rock your body",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "RRqmtPtl1Gs",
-      "title": "eXtatic - The Panic",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "34gLCexf2mQ",
-      "title": "DJ M@R - Phaze Zero",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "w5Yy4gS8kCc",
-      "title": "DJ Pablo - Battle Time",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "3571XVYoTk4",
-      "title": "Kava - The Gambler",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "vZMmk9l6zpU",
-      "title": "Mex - Way of the Exploding Crate",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "Kc8A2x0H0VY",
-      "title": "Marc Hype - The Mexican",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "Lp-xN-o6W90",
-      "title": "RJD2 - 1976",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "N9viPN8XrBc",
-      "title": "Smoove - I'm A Man",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "JTOnDzjVTKc",
-      "title": "Fader Gladiator & Das Lindenschmidt Orchechster - Beat Concerto",
-      "genre": "Freestyle / Breakdance"
-    },
-    {
-      "ytId": "i5vnIX1niDQ",
-      "title": "Eddie Amador - House Music",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "ik9cExHOazw",
-      "title": "Moodymann - I Can't Kick This Feeling When It Hits",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "q_OPhLouIL4",
-      "title": "Fish Go Deep - Deep, Like",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "UOC4VWQpnDM",
-      "title": "Gusto- Disco's revenge ",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "s_zPqWjDLwU",
-      "title": "Blue Six - Close to Home",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "7-BnB3xxUoA",
-      "title": "Nightcrawlers - Push The Feeling On",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "BxvBk_dSrKQ",
-      "title": "Move D - Jus House",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "CsxJzW-0mAg",
-      "title": "Booka Shade vs MANDY - body language",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "XpIrFglZfQU",
-      "title": "Leon Vynehall - It's Just",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "UwPKi1H8t9M",
-      "title": "Jaydee-Plastic Dreams",
-      "genre": "Deep House"
-    },
-    {
-      "ytId": "C7Okvrwtg6k",
-      "title": "Dynamix II - Just give the D.J. a break (Club Version)",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "I10Tc2fnQhM",
-      "title": "DJ icey - Escape",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "v5HEfbxk7Mw",
-      "title": "Planet Soul - Set U Free (Fever Mix)",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "b4Spg-WNCiA",
-      "title": "DJ Baby Anne - Trippin' The Bass ",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "AnUEGrVy5eg",
-      "title": "Tony Faline - Feel The Funk",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "4yMfEbisI-4",
-      "title": "Huda Hudia - C'mon Breakdown (Check This Out Mix)",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "OetKuu-8erk",
-      "title": "Plump DJs - Eargasm - The Funk Hits The Fan",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "qb-DhI3zIV8",
-      "title": "SOL BROTHERS - THAT ELVIS TRACK",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "5dF0RldDSn0",
-      "title": "Lionrock - Rude Boy Rock",
-      "genre": "Florida Breaks"
-    },
-    {
-      "ytId": "RkEXGgdqMz8",
-      "title": "2 Unlimited - No Limit",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "mS1dAovhXOc",
-      "title": "Cappella - Move on baby",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "Lk3lQRmIkoM",
-      "title": "2 Brothers on the 4th floor - Dreams (Will come alive)",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "vUb_S4e-Rd4",
-      "title": "Snap - The Power",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "7nE9xs2T1gs",
-      "title": "Dr. Alban - This Time I'm Free",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "HEXWRTEbj1I",
-      "title": "Haddaway - What Is Love ",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "p3l7fgvrEKM",
-      "title": "GALA - Freed from desire",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "ydd9Dn3bJlI",
-      "title": "La Bouche - Be My Lover",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "u3ltZmI5LQw",
-      "title": "Corona - Rhythm of the Night",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "dSy2DcATYUo",
-      "title": "Mo-Do - Eins Zwei Polizei",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "2GV_5dRrWH4",
-      "title": "Leila K - Open Sesame",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "dA0_6G_UOZM",
-      "title": "Technotronic - Hey Yoh, Here We Go",
-      "genre": "Hip House / Eurodance"
-    },
-    {
-      "ytId": "WVCsm0VIDcs",
-      "title": "Goa Gil - Acid Boom",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "EwhhAj55HXQ",
-      "title": "Infected Mushroom - Bust a Move",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "onquKz5SYRs",
-      "title": "ASTRAL PROJECTION - Mahadeva",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "Yorq47lK-A0",
-      "title": "hallucinogen - Alpha Centauri.",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "vQpVAWFvkbU",
-      "title": "1200 Micrograms - LSD",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "NqHfHSMmY-o",
-      "title": "s.u.n. project - dance of the witches",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "M-In23SYcNM",
-      "title": "Spacetribe - You Can Be Shiva",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "INYZs4kmnCk",
-      "title": "Talamasca - Overload",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "ZEUi03k2Amk",
-      "title": "Space Buddha - Silent Galaxy",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "2Ff2ojrCb4o",
-      "title": "Yahel Waves of Sound",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "Thi2FXdFkfM",
-      "title": "Electric Universe - The Prayer",
-      "genre": "Goa/PSY Trance"
-    },
-    {
-      "ytId": "XYZ0J0MytIA",
-      "title": "Oliver Lieb - Parallax",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "ynB-E722owE",
-      "title": "Humate - 3.1.",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "foxFjWKJXaE",
-      "title": "Marco V - Godd",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "FtAqOUvsJi4",
-      "title": "Omnia - Jesselyn",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "4yEDyEm186Q",
-      "title": "Megamind - Taub (Picotto Mix)",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "2P0WfhUx3gY",
-      "title": "Ernesto vs Bastian - Who's the starter",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "F6bWuO-KHy0",
-      "title": "timo maas - old school vibes",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "ahntwzwwET0",
-      "title": "Beautiful Mind - Marcel Woods",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "L5w9h6sR5x8",
-      "title": "Der Dritte Raum - Hale Bopp",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "_6RDh5bEF4g",
-      "title": "Breeder - The Chain",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "z7MXmcykwbk",
-      "title": "Ricky Le Roy - Metempsicosi",
-      "genre": "Tech Trance"
-    },
-    {
-      "ytId": "JCUPc9zVfyo",
-      "title": "Phuture - Acid Tracks",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "aQUIsgrlp10",
-      "title": "MAURICE - This Is Acid",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "lJnqRCwPeSw",
-      "title": "sleezy d - I ve lost control",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "wXuQb8Ln6_g",
-      "title": "Chip E - Time to Jack",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "emDEFtJIjy0",
-      "title": "A Guy Called Gerald - Voodoo Ray",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "QMyxLbpxS6U",
-      "title": "D Mob - We Call It Acieed!",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "QrHG0d_13tE",
-      "title": "Adonis - We're Rockin Down the House",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "SpjnzxtZ6Qg",
-      "title": "The Shamen - Move any mountain",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "j5IoLidzLH8",
-      "title": "Hit House Jack to the Sound of the Underground",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "IpeRShWMdYM",
-      "title": "S'Express - Theme from S'Express",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "W6CJmJ5p3Ow",
-      "title": "Bomb The Bass - Beat Dis",
-      "genre": "Acid House"
-    },
-    {
-      "ytId": "dVeCyaAccxY",
-      "title": "Komakino - Man on mars",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "ZnBeTPpr98g",
-      "title": "Push - Universal Nation",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "OonuVTc97cc",
-      "title": "RMB - Love Is An Ocean (Stephenson Remix)",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "k5NJV1c6zmQ",
-      "title": "Central Seven - Missing",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "6gHKECJYvr8",
-      "title": "Boccaccio Life - The secret wish",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "jlwPNroYv1U",
-      "title": "Cosmic Gate - 'Firewire' ",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "pg0BLZszvHM",
-      "title": "Space Frog - X-Ray (Follow Me)",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "xKgAqh8VA-k",
-      "title": "Trance Generators - Do U Wanna Balloon ",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "bxiqFV4Gf2U",
-      "title": "Brooklyn Bounce - Bass, Beats & Melody",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "QEO3XbVGXA4",
-      "title": "lee haslam-music is the drug",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "bMwH_66lxyk",
-      "title": "Blow Da Roof - Stimulant DJ's",
-      "genre": "Hardtrance"
-    },
-    {
-      "ytId": "_SYvDRFSEd4",
-      "title": "Dieselboy 'Midnight Express'",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "h0vS73yL6ys",
-      "title": "Evol Intent - Flipside",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "o8DkdMJys7Y",
-      "title": "Ice minus - Babylon",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "BMSp0b817aA",
-      "title": "ewun - guntalk",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "AtbQYCvLtdk",
-      "title": "Dred Bass - Technology",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "r6QR8A9_iFU",
-      "title": "Ed Rush & Optical - Chubrub",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "rCky845gi3w",
-      "title": "Calyx & Teebee & Hive - Salvation",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "-mfjV7j9m18",
-      "title": "Doc Scott - Michigan",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "rS-58UV4vfY",
-      "title": "Capone - Tudor Rose",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "KIGXGkzjAoc",
-      "title": "Bad Company - The Nine",
-      "genre": "Hardstep"
-    },
-    {
-      "ytId": "7MBaEEODzU0",
-      "title": "Aphex Twin - Window Licker",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "hfTAv8htci8",
-      "title": "Autechre - Nil",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "-t1_cEUEYuo",
-      "title": "The Black Dog - Nommo",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "se7w6pqBBxg",
-      "title": "Amon Tobin - Journeyman",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "BL-0nC1vpmI",
-      "title": "LFO-Freak",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "SqjZUyUtqYs",
-      "title": "Squarepusher - My Red Hot Car",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "hniwkuYF7Cs",
-      "title": "Funckarma - Fuse",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "gwDw2P0w-N4",
-      "title": "Bauri - Lakonia",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "orG5TIOU8Ts",
-      "title": "Boards Of Canada - Telephasic Workshop",
-      "genre": "Intelligent Dance Music"
-    },
-    {
-      "ytId": "elv-Egyp_To",
-      "title": "High Contrast - Racing Green",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "v9RZ484qlIg",
-      "title": "London Elektricity - The Great Drum & Bass Swindle",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "k7x51zWOBBs",
-      "title": "Utah Jazz - Take No More",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "eBR11H2Hho8",
-      "title": "Logistics - Icarus (feat. Hugh Hardie)",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "a6yAS__u2zE",
-      "title": "Marcus Intalex - Temperance [Soul:R]",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "v3OzptqCDvw",
-      "title": "Calibre - Even If",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "NiW-KG1pSpQ",
-      "title": "Q Project - Tears",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "S85q2xSpwUI",
-      "title": "Drumsound and Bassline Smith - Through The Night (Ft. Tom Cane) ",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "M97vR2V4vTs",
-      "title": "Rudimental - Waiting All Night ft. Ella Eyre ",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "qFDP9egTwfM",
-      "title": "Netsky - Rio  ft. Digital Farm Animals",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "ShNkIWWPvic",
-      "title": "J Majik & Wickaman - Crazy World feat. Kathy Brown",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "tS26xch5U24",
-      "title": "Sigma & Rita Ora - Coming Home HD",
-      "genre": "Liquid Funk"
-    },
-    {
-      "ytId": "-dohzrXT09w",
-      "title": "Human Resource - Dominator",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "fQO5yeVJdaI",
-      "title": "The Hypnotist - Hardcore You Know The Score",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "k3-uluEYsVw",
-      "title": "Channel X - Rave The Rhythm",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "Mx3LccRvidg",
-      "title": "T99 - Anasthasia",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "dN8e9b2ON8s",
-      "title": "L.A. STYLE - James Brown Is Dead",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "w1xGbEDs6-4",
-      "title": "U96 - Das Boot MTV",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "0PkD--DD0TM",
-      "title": "Quadrophonia - Quadrophonia",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "LPtuEfYv0PE",
-      "title": "D-Shake - Techno Trance",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "YLk8AMNCo24",
-      "title": "-APOTHEOSIS - O Fortuna",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "fqgUOKsHFvQ",
-      "title": "Ace The Space - 9 Is A Classic",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "gybB7HuC4gM",
-      "title": "LITTLE LITTLE - JUST THE WAY LIKE THIS",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "qQxytJEhCI4",
-      "title": "Fierce Ruling Diva - Rubb it in",
-      "genre": "Hardcore Techno / Rave"
-    },
-    {
-      "ytId": "-FDy-RVeI-A",
-      "title": "A Split Second - Flesh",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "HcbZUmLlNEo",
-      "title": "Lords of Acid - I Sit on Acid",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "WpV-ItIqRTs",
-      "title": "Ibiza - Amnesia",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "rAuoMZh8mVA",
-      "title": "DIRTY HARRY - D' BOP",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "dLmyey_18TM",
-      "title": "Confetti's - The Sound Of C",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "7vJJSXTfaTU",
-      "title": "Boytronic - Bryllyant",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "_U3wbk7eOMw",
-      "title": "Fatal Error - Fatal Error",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "zN-u2eJUVpc",
-      "title": "101 - Rock To The Beat (Club Mix)",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "ARHsb-fAw4U",
-      "title": "Traxx - Malfunction",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "6gGr8O40OXs",
-      "title": "CODE 61   Drop The Deal",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "SDFDUbCOiD0",
-      "title": "In-D - Virgin s In-D Sky's",
-      "genre": "New Beat"
-    },
-    {
-      "ytId": "I0KiAx6229A",
-      "title": "Grooverider - Where's Jack the Ripper",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "DvOF4tpUzGs",
-      "title": "Kenny Ken - Project One",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "9JISpdw5Pw8",
-      "title": "Jumping Jack Frost - Pornography",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "fRKRNJPaFf8",
-      "title": "Randall & Andy C - Sound Control",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "nyryDEPy4c8",
-      "title": "Mickey Finn - Reality",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "fp9h9gszscQ",
-      "title": "Trace & Nico - Squadron",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "JM07HYSGVho",
-      "title": "Pendulum - Blood Sugar",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "SVwTF7Nw3-w",
-      "title": "Technical Itch - The Rukus",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "CPed6Zqu0S4",
-      "title": "Dj Hidden-Chosen",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "WW57nFRGVYI",
-      "title": "Rawthang - Unity",
-      "genre": "Darkcore / Darkstep"
-    },
-    {
-      "ytId": "WPmhmmeajW0",
-      "title": "Artful Dodger Feat. Craig David",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "O1aaCEJ-x1g",
-      "title": "MJ Cole - Sincere",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "OQCQnARnKbc",
-      "title": "Shanks & Bigfoot - Sweet Like Chocolate",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "VVycT8k0tjM",
-      "title": "2 Step /Groove Chronicles - Stone Cold",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "F5PXdScoOrg",
-      "title": "Dj Luck & MC Neat - A Little Bit Of Luck ",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "94K9oK1YM1o",
-      "title": "T2 feat. Jodie - Heartbroken (Wideboys London Mix)",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "g7VhofoV3qs",
-      "title": "So Solid Crew - 21 Seconds ",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "LicesW1G55o",
-      "title": "tuff jam & todd edwards - wanting Jesus",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "lvVIyKHXJ9U",
-      "title": "UK Garage - Amira - My Desire (Dreem Teem Remix)",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "uR3Vw8J8vUo",
-      "title": "Double 99 - RIP Groove",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "jiXdKVitp6o",
-      "title": "Smokin Beats - Dreams - Feat Lyn Eden ",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "jYNVY_Yu1cs",
-      "title": "Scott Garcia Ft MC Styles - A London Thing",
-      "genre": "UK Garage"
-    },
-    {
-      "ytId": "ISy0Hl0SBfg",
-      "title": "Dizzee Rascal - Bonkers",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "HK1SpAy_cR4",
-      "title": "Roll Deep \"When I'm Ere\" music video",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "p48icgIs4sI",
-      "title": "Lady Sovereign - Blah Blah",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "mO3dl25gR_g",
-      "title": "Wiley - Eskimo",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "YNiYjYdOzOA",
-      "title": "The Bug - 'Function' ft Manga",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "WB6W4wQDPCw",
-      "title": "Musical Mob - Iron",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "m9nG_uctAkw",
-      "title": "Jammer Ft. Wiley, D Double E, Kano & Durrty Goodz - Destruction V.I.P",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "czBPOwSZVys",
-      "title": "Skepta - Man",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "5-s32ESIR-4",
-      "title": "Deekline - I Don't Smoke ",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "2nRUrCEuYi0",
-      "title": "Stanton Warriors - MPC ",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "j3xUloTrYA0",
-      "title": "CHIPMUNK X STORMZY - HEAR DIS",
-      "genre": "Grime"
-    },
-    {
-      "ytId": "FAYHTES4whs",
-      "title": "Moby - Porcelain",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "sGjfLuVn44Q",
-      "title": "Apollo 440 - Electro Glide In Blue",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "TwDOa-lvizM",
-      "title": "Nightmares on Wax - You Wish",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "5-wl7Xk5FoY",
-      "title": "Coldcut - Timber",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "MpMC2_SCY7w",
-      "title": "Hexstatic - 'Ninja Tune'",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "y2Eah_EGiDc",
-      "title": "Blue Boy - Remember Me ",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "3IWl77o3l50",
-      "title": "Bentley Rhythym Ace - Bentley's Gonna Sort You Out",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "rLMXRYjZgvs",
-      "title": "Utah Saints - B777",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "8ePgkZ6diEY",
-      "title": "Teargas and Plateglass - Arkhangelsk",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "N7eDIgsQiG0",
-      "title": "DJ Spooky - Anansi Abstrakt",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "D7wuSg14eCs",
-      "title": "Witchman - Chemical Noir",
-      "genre": "Ambient Braks / Illbient"
-    },
-    {
-      "ytId": "ZNO7-OYLI9U",
-      "title": "Alex Reece - Pulp Fiction",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "1ETABpY20oo",
-      "title": "Kruder & Dorfmeister  - Speechless",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "a5meT63flnM",
-      "title": "Origin Unknown - Valley Of The Shadows",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "aJMZsgDCl4o",
-      "title": "Roni Size - It's A Jazz Thing",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "8ifeoU79b5A",
-      "title": "E-Z Rollers - Walk This Land",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "7mekSjaYy0c",
-      "title": "LTJ Bukem - Inner Guidance",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "d3VmSvN1mts",
-      "title": "Omni Trio - Secret Life",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "ekbHXNyEnU4",
-      "title": "45Roller* ‎– Saturday Night Roller",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "d9jVW1x_Ris",
-      "title": "DJ Trace - Miles High",
-      "genre": "Intelligent DnB / Jazzstep"
-    },
-    {
-      "ytId": "xtppf3xkby4",
-      "title": "Noisia - Stigma",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "8UAUDbWrVhA",
-      "title": "Konflict - Messiah",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "BE6wt300Vfw",
-      "title": "Black Sun Empire - Breach",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "nwkzDNU5B2Q",
-      "title": "Ram Trilogy - Titan",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "gMlr-mMMYTc",
-      "title": "Decoder & Ice Minus - Drowning",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "nkldv7k3tC8",
-      "title": "Usual Suspects - Killa Bees",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "_reElm4cPOY",
-      "title": "Apache - Matrix",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "mqLZeU1u4UY",
-      "title": "The Qemists - Lost Weekend (I Got Your Money)",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "uyn7pf3ELGc",
-      "title": "Signs - Plasma",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "PX8I8vVhF2M",
-      "title": "Trei - Backburner",
-      "genre": "Neurofunk"
-    },
-    {
-      "ytId": "zI7DferroGA",
-      "title": "Robert Miles Children",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "lpkLcfbOra4",
-      "title": "BBE - 7 days and one week",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "G9-1r1d0Hyo",
-      "title": "Zhi-Vago - Celebrate (The Love)",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "kYwRXqjiAZ8",
-      "title": "DJ Dado - X-Files",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "EyBsoG8UWmc",
-      "title": "W P - ALEX REMARK - Pyramid (In Dream)",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "9o2cV-FpoHo",
-      "title": "Cafe Del Mar - Energy 52",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "ltpCS5P0zCw",
-      "title": "Chicane - Offshore",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "LTERifplFcM",
-      "title": "Sunlounger - Sunkissed ",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "2QAlaBcWC5o",
-      "title": "Nalin & Kane - Beachball",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "Y0ye9oFD1vE",
-      "title": "Miro - Emotions of Paradise",
-      "genre": "Ibiza/Dream House"
-    },
-    {
-      "ytId": "gdvweWe6ACg",
-      "title": "Spiral Tribe - FFWD THE REVOLUTION",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "UVYuNEQdIKc",
-      "title": "69db - OrnOrm",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "gcnyPy32WRQ",
-      "title": "Crystal Distortion - Power to the Pipe",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "JHSiuaO_09c",
-      "title": "Jack acid - acid tension",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "DAfntnwU3bo",
-      "title": "SuBuRbASs - Yes PaPaRoubek",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "JMoUwIOKhwc",
-      "title": "Mala (Addictik) - La Mescalina",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "FrEADHbX5fE",
-      "title": "Kaos - 23 aera",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "tKwjrv-ivow",
-      "title": "Heretik - Beuns-Game Over",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "tQ_ylWgiRqA",
-      "title": "Metek Sound System - Metek Style",
-      "genre": "(free)tek(k)no"
-    },
-    {
-      "ytId": "KkqX2h99OXY",
-      "title": "Dave Nada - Moombahton",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "e7eZUGB9HKU",
-      "title": "Major Lazer - Light It Up (feat. Nyla & Fuse ODG)",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "EUD39sJUue8",
-      "title": "Diplo & GTA - Boy Oh Boy",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "X-8VeSDgAgg",
-      "title": "Ape Drums - Bashment",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "3ArOBAt5Ml0",
-      "title": "Dillon Francis, Skrillex - Bun Up the Dance",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "LPTa7Fq2T1M",
-      "title": "Tropkillaz - Que Passa Amigo",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "YzMdE2tcERU",
-      "title": "Munchi - La Brasileña Ta Montao (feat. Angel Doze)",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "3pVxWok4iLA",
-      "title": "Torro Torro & Long Jawns - The Pump",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "u9ESD5M5pBQ",
-      "title": "ETC!ETC!: Temblando",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "LII5vsz7niY",
-      "title": "Jesse Slayter - Thick",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "UwsR5LC0mII",
-      "title": "[Gelöschtes Video]",
-      "genre": "Moombahton"
-    },
-    {
-      "ytId": "KandVSZbZAM",
-      "title": "Skream - Exothermic Reaction",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "VIpnaZMa4Yg",
-      "title": "Burial: Southern Comfort",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "-udpkxPnMRY",
-      "title": "Kode9 - Black Sun",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "jVKboRPgu0U",
-      "title": "Benga - Crunked Up",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "QrRcEfulv3U",
-      "title": "Digital Mystikz - Earth A Run Red",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "Ky5Mt2PLf9E",
-      "title": "Dubstep - Mala - Changes",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "Fbi7Y5NysYs",
-      "title": "Loefah - The Goat Stare",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "nVVCDneVxm8",
-      "title": "Caspa & Rusko - Blouse an Skirt",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "43XLXmx5tQ0",
-      "title": "Vex'd - Corridor",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "7280__uzZus",
-      "title": "MRK1 - Grit",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "yEpuq51ncNk",
-      "title": "Distance - V",
-      "genre": "Dubstep"
-    },
-    {
-      "ytId": "TguJjg-p2mE",
-      "title": "The Chemical Brothers - Chemical Beats",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "ht7FQX3zpqQ",
-      "title": "Fluke - Absurd",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "2C0jyGwxUZk",
-      "title": "The Crystal Method - Comin` Back",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "SP6cmVZbJJU",
-      "title": "The Prodigy - Smack My Bitch Up",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "F7jSp2xmmEE",
-      "title": "Fatboy Slim - Right Here Right Now",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "jaI7PDSRELY",
-      "title": "Overseer - Basstrap",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "fCkKx5B8OK4",
-      "title": "Junkie xl- Billy Club",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "maP6q3D4Hf0",
-      "title": "Lunatic Calm - Leave You Far Behind",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "XGYjxiGsy8g",
-      "title": "Andy Hunter - Come On",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "AFn-Wr3qDTY",
-      "title": "07 We Got The Gun",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "xIXCVZ9evuo",
-      "title": "PropellerHeads - SpyBreak!",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "auWbz0atKXE",
-      "title": "Eboman - Donuts with Buddha",
-      "genre": "Chemical Breaks"
-    },
-    {
-      "ytId": "F6Y7lcvubhU",
-      "title": "Underworld - Rez",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "8D56eqR-qiM",
-      "title": "Leftfield - Afro - Left",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "7rw4S3jqqz4",
-      "title": "The Aloof - Bittersweet",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "zzHmXaUSL6o",
-      "title": "Bedrock Feat. KYO - For What You Dream Of",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "tDRtjooGe1I",
-      "title": "Spooky - Don't Panic",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "GTYTJ807wS0",
-      "title": "Austin Leeds - Force 51",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "V7aELkYPIXA",
-      "title": "Cass - Emotion Surfer ",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "ryIM3EUE6nI",
-      "title": "Rhythm Reigns - Fuel ",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "ipaqnOeKsDA",
-      "title": "Poseidon - Supertransonic (Timo Maas Mix)",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "szbxT0QDqn8",
-      "title": "Mara- Desanitize (Fakkindaddydub)",
-      "genre": "Progresssive House"
-    },
-    {
-      "ytId": "6HzyUHxmkg0",
-      "title": "TNGHT - Higher Ground (Hudson Mohawke x Lunice)",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "qV0LHCHf-pE",
-      "title": "Baauer - Harlem Shake",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "KNByf1o4T_8",
-      "title": "Flosstradamus feat. Casino - Mosh Pit",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "oIwFJNguQgY",
-      "title": "Yellow Claw - Shotgun ft. Rochelle",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "Kz1CqHw35Bs",
-      "title": "RL Grime - Scylla",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "mUiEqZDPIXY",
-      "title": "UZ - Trap Shit V17",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "Ya_XddpkeJ8",
-      "title": "Bro Safari feat. DJ Craze - Spooked",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "Zk7Dg30tCDU",
-      "title": "TroyBoi - Afterhours (feat. Diplo & Nina Sky)",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "k_MWuP2Qj7U",
-      "title": "Hudson Mohawke - Chimes",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "3FPwcaflCS8",
-      "title": "Aero Chord - Surface",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "Io0fBr1XBUA",
-      "title": "The Chainsmokers - Don't Let Me Down ft. Daya",
-      "genre": "Trapstep / EDM Trap"
-    },
-    {
-      "ytId": "HdzI-191xhU",
-      "title": "ODESZA - Say My Name (feat. Zyra)",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "Ly7uj0JwgKg",
-      "title": "Flume - Never Be Like You feat. Kai",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "_pABewcNigQ",
-      "title": "Manila Killa - All That's Left feat. Joni Fatora",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "0zrAuAM2DEw",
-      "title": "Bearson - Want You (feat. Cal)",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "i9bmuOl7QN4",
-      "title": "Mazde - Battas (feat. LissA)",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "AQI0RTXwmjY",
-      "title": "Cashmere Cat - Rice Rain",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "n4yu_oUM9TU",
-      "title": "Wave Racer - Streamers",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "1_WeBcBeuWU",
-      "title": "LIDO - MONEY ",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "sOYd7AEoMtI",
-      "title": "XXYYXX - Echo Volture",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "rI-t2M0t63s",
-      "title": "[Future Bass] - Kasbo - Kaleidoscope",
-      "genre": "Future Garage/Bass"
-    },
-    {
-      "ytId": "8tIgN7eICn4",
-      "title": "DJ Tiesto - Adagio For Strings",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "gTPSxbQ9sbo",
-      "title": "Rank 1 - Airwave ",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "QKwK-ZhTurg",
-      "title": "Binary Finary - 1998 ",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "WdGwqUtJ03o",
-      "title": "Ferry Corsten - Beautiful",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "paSm1qTy9yg",
-      "title": "Svenson & Gielen - The Beauty Of Silence",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "Q2C2V3kac08",
-      "title": "Armin van Buuren feat. Kensington - Heading Up High",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "8JppHhLYEvM",
-      "title": "Cygnus X - Superstring",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "XHKImaLHkns",
-      "title": "System F - Dance Valley Theme 2001 ",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "aGlEJEXDJj8",
-      "title": "Dash Berlin - Feel U Here",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "amRzeWrbAq8",
-      "title": "DJ Tatana ft. Energy - End of Time",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "3-UizNvummY",
-      "title": "Members of Mayday - 10 in 01",
-      "genre": "Epic Trance"
-    },
-    {
-      "ytId": "fSwI2AFlki4",
-      "title": "Joey Beltram - Energy Flash ",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "eZlARaT5_3w",
-      "title": "Mescalinum United - We Have Arrived",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "sq1ZYSuEnu8",
-      "title": "Richie Hawtin - Minus / Orange 1",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "CfAzcz33PyE",
-      "title": "Dave Clarke - The Storm (Red Three)",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "WflVHf43E40",
-      "title": "Planetary Assault Systems - Rip The Cut",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "VzhAyLlJxT0",
-      "title": "DJ Hell - Three Degrees Kelvin",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "q49Bn9xibQI",
-      "title": "Chris Liebing - Gassenhauer",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "Qx1lfuc7qVM",
-      "title": "Johannes Heil Paranoid Dancer",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "-D9tNCEe9ek",
-      "title": "CODE INDUSTRY - FURY",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "gZHZQ-RWaBU",
-      "title": "Oliver Klitzing - I Like That Beat",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "Hrw0IIKrrFM",
-      "title": "Sven Wittekind - Darkness All Night",
-      "genre": "Industrial techno"
-    },
-    {
-      "ytId": "QZUFbKKVAdU",
-      "title": "IG Culture - Girl U Need A Change Of Mind",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "XUpDHVInXCs",
-      "title": "Domu - Unfazed",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "mtjg6MIl52M",
-      "title": "Bugz In The Attic -  It Don't Work Like That",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "8iNzHHwt2zI",
-      "title": "Volcov - Sweet Love",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "SSJXkizPABs",
-      "title": "Modaji ft. Jag - No Disguise",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "nQkSRybhPTk",
-      "title": "Afronaught - Transcend Me",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "Ju3UiYuK1s4",
-      "title": "neon phusion - timeless motion",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "cUu6y35I9us",
-      "title": "Vikter Duplaix - Make A Baby ",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "ls1FRm48v8Y",
-      "title": "NEW SECTOR MOVEMENTS - Groove Now",
-      "genre": "Broken Beats"
-    },
-    {
-      "ytId": "_fX4qoruQik",
-      "title": "Venetian Snares - Szamar madar",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "0X34Lgmz8PI",
-      "title": "Bong-Ra '666MPH'",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "CPzVWlcefh0",
-      "title": "V/Vm - sabam",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "_qAEdi68caM",
-      "title": "Speedranch vs End - Tea",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "MKp30C3MwVk",
-      "title": "Igorrr - Tout Petit Moineau",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "QzvRShWU8No",
-      "title": "Atari Teenage Riot - Sick to Death",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "aJP7QJ1IPIg",
-      "title": "Ec8or - Dynamite",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "8np68opO93Y",
-      "title": "SHIZUO - SWEAT",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "YLDEbd1HCUM",
-      "title": "Bomb 20 - Burn the shit down!",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "OnmbG-kzyHo",
-      "title": "Panacea - Found A Lover",
-      "genre": "Digital Hardcore"
-    },
-    {
-      "ytId": "fXAnXT8Hm2A",
-      "title": "Dexplicit Ft. Lauren Mason- Not your baby (DJ Q special)",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "WTsHWzvJWDQ",
-      "title": "T2 - Heartbroken (Ft. Jodie)",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "ncs57OkTIxM",
-      "title": "Smasher - Watch Your Back",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "hqFRq1xlOOg",
-      "title": "TS7 - Heartlight (Ft. Taylor Fowlis) ",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "84QaqN0zayk",
-      "title": "SUPA D - SHAKE LOOSE",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "1Mhi0RfXHx4",
-      "title": "Karizma -  Rock Away",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "s1jp94Psx18",
-      "title": "Mosca - Bax",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "Dhi8CLnk96M",
-      "title": "Omar & Zed Bias - Dancing",
-      "genre": "UK Funky / Bassline"
-    },
-    {
-      "ytId": "YJVmu6yttiw",
-      "title": "SKRILLEX - Bangarang feat. Sirah",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "OanbqQP2hBY",
-      "title": "Datsik - Firepower",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "mjKzV9gl490",
-      "title": "EXCISION - Brutal ",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "30ScfAfEBJg",
-      "title": "Noisestorm - Breakdown",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "EwDIs6zTBeA",
-      "title": "[Drumstep] - Feint - Formless",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "VUnjBY7NIso",
-      "title": "Detzky - Shadow Dance",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "24RbLt2qGfY",
-      "title": "Au5 & Fractal - Smoke",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "z5hALgSaSIo",
-      "title": "Vonikk - Superstar",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "m0psosrTuas",
-      "title": "Gramatik - So Much For Love ",
-      "genre": "Post- Dubstep"
-    },
-    {
-      "ytId": "-xLEYF25bHs",
-      "title": "Sharkey & Eclipse- The Warning",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "Ph5Ag_jzm0w",
-      "title": "Bass-X vs Scott Brown - Pilgrim (Version 2000)",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "4phIs_1yRLg",
-      "title": "Scott Majestik - Acid Dreams",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "S3YhxLHhvpg",
-      "title": "Kaos & Ethos — Lost",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "f00Ys9G6JyY",
-      "title": "Brisk & Trixxy- Back To The Top",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "GI6EOQ0Zuq8",
-      "title": "Dj Buzz Fuzz - Frequencies",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "FVgskJ6ND58",
-      "title": "Mr. Gasmask - Jawbreaker",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "CrA_D8Vlj7c",
-      "title": "Cellblock-X - Return Of Spoo",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "0C9Ly2mjnQ8",
-      "title": "Pzylo - X-trabass",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "IczFLXmVoJU",
-      "title": "Acidolido - Sabotage",
-      "genre": "Trancecore & Acidcore"
-    },
-    {
-      "ytId": "Zjp2HUY7dQY",
-      "title": "Antipop Consortium - Ghostlawns",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "poEKWbLO9aU",
-      "title": "Push Button Objects - 360 Degrees ft Mr Lif, Del & DJ Craze",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "fJY7BMzx7Iw",
-      "title": "Prefuse 73 - Perverted Undertone",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "j81fYZVvFh4",
-      "title": "edIT Ants",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "H-k_Eg7zXuc",
-      "title": "The Glitch Mob - We Can Make The World Stop",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "Sk9XYQMRiLY",
-      "title": "Pretty Lights - Finally Moving",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "st75F4Wy7oM",
-      "title": "Rustie - First Mythz ",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "CESYvCI66rY",
-      "title": "Funkstörung - Grammy Winners",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "Aclft-KytMI",
-      "title": "Dabrye ft MF Doom - Air",
-      "genre": "Glitch Hop"
-    },
-    {
-      "ytId": "YcVPnX-nML4",
-      "title": "Kid Cudi - Day 'N' Nite (Crookers Remix)",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "VABjk9mxU2k",
-      "title": "Hervé - Together",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "Z3fh-yZSWoU",
-      "title": "Jack Beats - Get Down ",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "iODdvJGpfIA",
-      "title": "Fake Blood - Mars ",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "PRqRTtyKPMg",
-      "title": "AC Slater - U Got 2",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "CWXFhyQy2Xc",
-      "title": "Mord Fustang - Elite Beat Agent",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "PPwCmhvmHeM",
-      "title": "Huoratron - $$ Troopers",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "OkvXO45XL-c",
-      "title": "Wolfgang Gartner - Undertaker",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "7eZIbmq5Jiw",
-      "title": "[Electro House] Virtual Riot - Energy Drink",
-      "genre": "Fidget House / Complextro"
-    },
-    {
-      "ytId": "_WTBkj8gFfI",
-      "title": "ADAM FREELAND - WE WANT YOUR SOUL",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "CI8DW1Z-PNU",
-      "title": "Koma & Bones - Morpheus ",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "IoGKgpLi9J0",
-      "title": "Rennie Pilgrem - Paranoia",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "-LxAxQQNn2U",
-      "title": "Tayo - Fire Good",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "A1Ici26u__4",
-      "title": "Friction & Spice - You Make Me Feel So Good",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "7B4S3AC5j_c",
-      "title": "Ils Revolver",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "wr2o8qqc-1Y",
-      "title": "PMT - Gyromancer",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "AcICrHac3z4",
-      "title": "Freq Nasty - Goose",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "ajYUU606G1w",
-      "title": "Digital Witchcraft - Snowday",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "NJrmm5P5WSw",
-      "title": "Hybrid - Just For Today",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "sXqYvy10Mbg",
-      "title": "Momu - Donner Pass ",
-      "genre": "Nu Skool Breaks"
-    },
-    {
-      "ytId": "9lDCYjb8RHk",
-      "title": "Soul Sonic Force - Planet Rock",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "bGd_HkpVaJs",
-      "title": "Arabian Prince & The Sheiks  - Situation Hot",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "L4472HNKXDI",
-      "title": "C.O.D. - In The Bottle",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "-9fjN5lUgYo",
-      "title": "Whodini - Magic's Wand",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "7VaGGZplMPs",
-      "title": "Tyrone Brunson - The Smurf",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "73omlAllMm4",
-      "title": "Bassline - Mantronix",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "qjFs9CPGhts",
-      "title": "The Egyptian Lover - Egypt, Egypt",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "qPpa5gs536Y",
-      "title": "The Jonzun Crew-Pack Jam",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "ykK0uEjSsqY",
-      "title": "Hashim - Al-Naafiysh (The Soul)",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "xDj54ZdJw_w",
-      "title": "Twilight 22 - Electric Kingdom",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "r0L_AVc1OjE",
-      "title": "Man Parish - Boogie Down Bronx",
-      "genre": "Electro"
-    },
-    {
-      "ytId": "30eXKMfrVcw",
-      "title": "The Age Of Love - The Age Of Love",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "FJjD6BVGeGQ",
-      "title": "Cosmic Baby - The Space Track",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "5A9OIIapSko",
-      "title": "ATB - 9PM (Till I Come) -",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "8Eq0i187kvE",
-      "title": "Stella - Jam and Spoon",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "ZKKoXgrDMPM",
-      "title": "Dance 2 Trance - Power Of American Natives",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "2l7wW7FLnbY",
-      "title": "Resistance D - Throm",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "Z7Gn1ZuNd6Q",
-      "title": "Electric Skychurch - \"Deus\"",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "S6ruUooMK9w",
-      "title": "Hardfloor - Acperience 1_video_edit ",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "YXwdMYEPjCU",
-      "title": "Art Of Trance - Kaleidoscope",
-      "genre": "Classic Trance"
-    },
-    {
-      "ytId": "10pmPiK8pi8",
-      "title": "Fedde Le Grand - Put Your Hands Up 4 Detroit",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "a0fkNdPIIL4",
-      "title": "Benny Benassi - Satisfaction",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "PkQ5rEJaTmk",
-      "title": "Swedish House Mafia - One (Your Name)",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "gvaLFPDWtdA",
-      "title": "Laidback Luke - Rocking with the Best",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "r6E3J4GPpjc",
-      "title": "Don Diablo - On My Mind",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "V775PPuBc7Y",
-      "title": "Sidney Samson - Riverside",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "AYzgexJVCkw",
-      "title": "Vato Gonzalez - Push Riddim",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "rHqO02q4b18",
-      "title": "Afrojack - Unstoppable ",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "li6_41Fusbw",
-      "title": "Chuckie - Let The Bass Kick",
-      "genre": "Dutch House"
-    },
-    {
-      "ytId": "4Fu_uld7SIQ",
-      "title": "M.A.N.I.C. - I'm Coming Hardcore",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "gXCN1DhHTZA",
-      "title": "SL2 - On A Ragga Tip",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "2_bL0hFyslg",
-      "title": "Altern 8 Activ-8 (Come with me)",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "E8v7dRXuzEw",
-      "title": "Acen - Trip II the Moon (Part 1)",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "2koaW18Vm1I",
-      "title": "Phuture Assassins - Future Sound",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "CYns_QBpJG0",
-      "title": "Shut Up And Dance - Raving I'm Raving",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "7dpvLjtT7jI",
-      "title": "RatPack - Searching For My Rizla",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "ns3rmEHfkCI",
-      "title": "Rhythm Foundation - Let The Whole World Know",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "6rALSXnYpmQ",
-      "title": "New Atlantic - I Know",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "WKHKN7odpbY",
-      "title": "Hyper Go Go - Never Let Go (piano mix)",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "0H9jQQVnU2g",
-      "title": "Together - Hardcore Uproar",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "bq4JcPxAdd0",
-      "title": "Pierre Feroldi feat Linda Ray - Movin Now",
-      "genre": "Breakbeat Hardcore"
-    },
-    {
-      "ytId": "E8PhL_u9Q5Y",
-      "title": "Robert Hood - And Then We Planned Our Escape",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "Nsct-e-HVE0",
-      "title": "Plastikman - Spastik",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "eaVY5Y13sc0",
-      "title": "Basic Channel - Octagon",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "l_RfediFJFQ",
-      "title": "Green Velvet - Flash",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "Xi7MJn7NoTc",
-      "title": "Gas - Klang",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "EoMksOzl-xs",
-      "title": "Fragile / Mike Ink",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "giFk55cBjww",
-      "title": "Ø (Mika Vainio) - Stratostaatti",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "AESZ1I-r44E",
-      "title": "Safety Scissors - Fridgelife",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "nxMaf7NSKBE",
-      "title": "Daniel Bell - Baby Judy",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "zvZjswJ-YY4",
-      "title": "Kenny Larkin - Paranoid",
-      "genre": "Minimal Techno"
-    },
-    {
-      "ytId": "lx9-fjlh7Y4",
-      "title": "Goldie - Inner City Life",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "W8Mh7ImxVKY",
-      "title": "Dj Rap - Tibetan Jungle",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "rqAluSHBI3o",
-      "title": "Kemistry & Storm - Signature",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "FZ68IUVYGg0",
-      "title": "Photek - Complex",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "Vdw5OhOPmuM",
-      "title": "Remarc - Drum N' Bass Wise",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "ONa4LKiljr8",
-      "title": "Q Project - Champion Sound",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "1GU9p35eNH4",
-      "title": "Dillinja - Twist 'Em Out",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "Vt39DQGbHTg",
-      "title": "DJ Fabio - Kings of the Jungle VI",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "mL2Bgj-za5k",
-      "title": "M Beat feat General Levy Incredible",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "QL4GQ5H0lkc",
-      "title": "Congo Natty Junglist",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "es3RMEBx0pg",
-      "title": "Shy Fx - Original Nuttah",
-      "genre": "Oldschool Jungle/DnB"
-    },
-    {
-      "ytId": "9XCwBljqsnk",
-      "title": "DJ Aphrodite - King Of The Beats (2015)",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "mkzMHEtYu5Y",
-      "title": "Urban takeover -  Bad ass (urban mix)",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "l2KZoWLot0g",
-      "title": "Super Sharp Shooter - The Ganja Kru",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "O8MlkiGsVMc",
-      "title": "Mulder - Stick Up Kid (Urban Takeover)",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "vXNnJHE3TPc",
-      "title": "Andy C - New Era",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "43Cnk0079iA",
-      "title": "Mampi Swift - Guess Who",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "GQuj6YQ-WX0",
-      "title": "DJ Hazard - It's A Secret",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "G4s7pFHvAI4",
-      "title": "Majistrate - Feel So Good. feat Jessica Luck [Sweet Tooth Recordings]",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "7IsmYk7-b9Q",
-      "title": "Sub Zero - Straight In",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "rPRkYWVinF0",
-      "title": "Chase & Status feat. Takura \"No Problem\"",
-      "genre": "Jump Up"
-    },
-    {
-      "ytId": "ZWmrfgj0MZI",
-      "title": "Massive Attack - Unfinished Sympathy",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "PdflxJTFl8w",
-      "title": "DJ Shadow - In/Flux",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "25y3cMC9i94",
-      "title": "Tricky - 'Aftermath' ",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "4qQyUi4zfDs",
-      "title": "Portishead - Glory Box",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "--wy8QmLlM8",
-      "title": "Morcheeba - The Sea - Big Calm (1998)",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "2eBZqmL8ehg",
-      "title": "Sneaker Pimps - 6 Underground - Official Video",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "rmWGaKgXnHM",
-      "title": "The Richest Man In Babylon by Thievery Corporation",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "kdQycB5I6C4",
-      "title": "U.N.K.L.E. - Be There",
-      "genre": "Trip Hop"
-    },
-    {
-      "ytId": "_YCGtT_FRYg",
-      "title": "Rob dougan clubbed to death videoclip",
-      "genre": "Trip Hop"
-    }
-  ]
+  "tracks": {
+    "tech house": [
+      {
+        "ytId": "8rXD2Vnll0E",
+        "title": "Eddie Richards ‎- Be Still"
+      },
+      {
+        "ytId": "yGSO6cZ36XU",
+        "title": "Octave One - I Believe"
+      },
+      {
+        "ytId": "infb1G4nD5s",
+        "title": "Colin Dale - You Know How (Mothersole & Freemans 'Freesole Dub')"
+      },
+      {
+        "ytId": "ulncNi-acYo",
+        "title": "Laurent Wolf feat Well Talmer - Together"
+      },
+      {
+        "ytId": "l3rJqLFswnY",
+        "title": "Blake Baxter - Get Layed"
+      },
+      {
+        "ytId": "rjYmzjjNf6w",
+        "title": "Terry Francis - Loving you"
+      },
+      {
+        "ytId": "8BTUfA4kNlg",
+        "title": "Gene Farris - Move Your Body"
+      },
+      {
+        "ytId": "vonZzW0rv34",
+        "title": "Jay Tripwire - How We Used To Do It"
+      },
+      {
+        "ytId": "K5ZKlFhcRoA",
+        "title": "Housey Doingz - Lounge"
+      }
+    ],
+    "Ghetto House": [
+      {
+        "ytId": "6_CZoM72ITo",
+        "title": "Amine Edge & DANCE - Halfway Crooks"
+      },
+      {
+        "ytId": "PgpnWJu7rog",
+        "title": "Destructo - Party Up ft. YG"
+      },
+      {
+        "ytId": "s-nrvyOTDIc",
+        "title": "DJ Deeon - Let Me Bang"
+      },
+      {
+        "ytId": "1txVyyLkb6g",
+        "title": "Shiba San - OKAY"
+      },
+      {
+        "ytId": "Gk88dljeg6E",
+        "title": "Jammin Gerald - Pump That Shit Up"
+      },
+      {
+        "ytId": "XzxIHXZdDc0",
+        "title": "DJ Godfather - Player Haters in Dis House"
+      },
+      {
+        "ytId": "8Pnd2JDoX9g",
+        "title": "Disco D - You Need Another Drink"
+      },
+      {
+        "ytId": "aHiPaL0MTUk",
+        "title": "DJ ASSAULT - Raccoon"
+      },
+      {
+        "ytId": "UdNEASBplDs",
+        "title": "DJ Chip - hold up wait a minute"
+      },
+      {
+        "ytId": "ouMTwFpZNso",
+        "title": "DJ Rashad - Drop Juke Out"
+      }
+    ],
+    "French House": [
+      {
+        "ytId": "D8K90hX4PrE",
+        "title": "Daft Punk - Technologic"
+      },
+      {
+        "ytId": "Yu0f7Tj_PaI",
+        "title": "Cassius - 1999"
+      },
+      {
+        "ytId": "Wn_Mt3agjos",
+        "title": "Etienne de Crecy & Alex Gopher - Overnet"
+      },
+      {
+        "ytId": "yatShLljhlo",
+        "title": "Armand Van Helden - Into Your Eyes"
+      },
+      {
+        "ytId": "4p_WxAA-OcQ",
+        "title": "Laurent Garnier - Man with the red face"
+      },
+      {
+        "ytId": "qmsbP13xu6k",
+        "title": "Mr Oizo - Flat beat"
+      },
+      {
+        "ytId": "TUC2b-OSZ00",
+        "title": "Stardust - Music Sounds Better With You"
+      },
+      {
+        "ytId": "YCRu4zFLYxo",
+        "title": "Roger Sanchez - Another Chance"
+      },
+      {
+        "ytId": "3J0j5QDJkGA",
+        "title": "Freemasons feat. Siedah Garrett - Rain Down Love"
+      },
+      {
+        "ytId": "5rAOyh7YmEc",
+        "title": "Basement Jaxx - Where's Your Head At"
+      },
+      {
+        "ytId": "dH8WvayAo1M",
+        "title": "Mousse T. feat. Hot 'n' Juicy - Horny '98"
+      }
+    ],
+    "Minimal House": [
+      {
+        "ytId": "jtQ-3Pua2Ms",
+        "title": "Akufen - Architextures 1"
+      },
+      {
+        "ytId": "h0i1Szq6GM8",
+        "title": "Ricardo Villalobos - Dexter"
+      },
+      {
+        "ytId": "O53-C8fMXhI",
+        "title": "Luomo - Tessio"
+      },
+      {
+        "ytId": "uRJRjJuwZd0",
+        "title": "Farben - Swinn Off"
+      },
+      {
+        "ytId": "c0Nu1qwT8os",
+        "title": "Matthew Dear- Deserter"
+      },
+      {
+        "ytId": "UDyTfFPBAf4",
+        "title": "D.Diggler - Signals"
+      },
+      {
+        "ytId": "lCIEI8Bg5Aw",
+        "title": "Benjamin Wild - Anschlusstreffer"
+      },
+      {
+        "ytId": "v2VpuQwy3DI",
+        "title": "Isolée - Floripa"
+      },
+      {
+        "ytId": "0J72ImA38nE",
+        "title": "John Tejada - The End Of It All"
+      },
+      {
+        "ytId": "Pb2o__S9K6s",
+        "title": "Mosca - Clinical Trial"
+      }
+    ],
+    "Chicago/Garage House": [
+      {
+        "ytId": "LOLE1YE_oFQ",
+        "title": "Frankie Knuckles - Your Love"
+      },
+      {
+        "ytId": "ts8iBs3tpmw",
+        "title": "Larry Heard a.k.a. Mr. Fingers - Can You Feel It?"
+      },
+      {
+        "ytId": "QAR8cq5Bl94",
+        "title": "Marshall Jefferson - move your body"
+      },
+      {
+        "ytId": "wI1rPWlgFxg",
+        "title": "Farley 'Jackmaster' Funk - Love Can't Turn Around"
+      },
+      {
+        "ytId": "qUeMFG4wjJw",
+        "title": "Jesse Saunders - On and On"
+      },
+      {
+        "ytId": "ZaHUK5GnDgE",
+        "title": "STEVE \"SILK\" HURLEY - Jack Your Body"
+      },
+      {
+        "ytId": "dnvf0mwIIoY",
+        "title": "Kariya - Let Me Love You For Tonight"
+      },
+      {
+        "ytId": "Yz1xMiyrfsw",
+        "title": "Joe Smooth - Promised Land (Club Mix)"
+      },
+      {
+        "ytId": "U1i5GiE17mw",
+        "title": "Esther Williams - I'll Be Your Pleasure (Larry Levan Mix)"
+      },
+      {
+        "ytId": "r_aFDMG6vWQ",
+        "title": "The 28th Street Crew - I Need A Rhythm"
+      },
+      {
+        "ytId": "Dzy4YlwkJVI",
+        "title": "TC - 1991"
+      },
+      {
+        "ytId": "EbfqyPvfP-4",
+        "title": "Mr Lee - Come To House"
+      }
+    ],
+    "Hardtechno": [
+      {
+        "ytId": "LOnWVi8mOeY",
+        "title": "Frank Kvitta - Reinsteckefuchs"
+      },
+      {
+        "ytId": "JtUv1yUsT68",
+        "title": "Weichentechnikk & Waldhaus - Es gibt kein Battle"
+      },
+      {
+        "ytId": "l0Zl-Baw48w",
+        "title": "KillSwitch & Reset - Gazowany"
+      },
+      {
+        "ytId": "2A8sVbz0uU4",
+        "title": "Greg Notill - Transcendance"
+      },
+      {
+        "ytId": "pYX_GIpcTIE",
+        "title": "DJ Amok - Nightmare"
+      },
+      {
+        "ytId": "vODHo5omPog",
+        "title": "dj rush my palazzo"
+      },
+      {
+        "ytId": "4AzA7zjtSao",
+        "title": "Arkus P Hexen Process"
+      },
+      {
+        "ytId": "iDVYFaiLEoM",
+        "title": "Jan Fleck - Come Get Some"
+      },
+      {
+        "ytId": "L7ap4o_zYJo",
+        "title": "Felix Kröcher - Travel Pussy (Dont stop popp that Pussy)"
+      }
+    ],
+    "Nu Disco": [
+      {
+        "ytId": "kIC0aQ56ASE",
+        "title": "The Shapeshifters - Lola's Theme"
+      },
+      {
+        "ytId": "4H5I6y1Qvz0",
+        "title": "Scissor Sisters - I Don't Feel Like Dancin'"
+      },
+      {
+        "ytId": "sy1dYFGkPUE",
+        "title": "Justice - D.A.N.C.E."
+      },
+      {
+        "ytId": "KZoVM_ZfdY8",
+        "title": "Dimitri From Paris - Not Quite Disco"
+      },
+      {
+        "ytId": "cOIIbxEtebg",
+        "title": "Lindstrøm - Closing Shot"
+      },
+      {
+        "ytId": "L_fCqg92qks",
+        "title": "Eric Prydz - Call On Me"
+      },
+      {
+        "ytId": "I2dfGC1oziE",
+        "title": "VITALIC - Poison Lips"
+      },
+      {
+        "ytId": "N3kkNfH4yco",
+        "title": "Michael Gray - The Weekend"
+      },
+      {
+        "ytId": "7BurNCK5Pc8",
+        "title": "Chromeo - Come Alive (feat. Toro y Moi)"
+      },
+      {
+        "ytId": "xPrgVald-fc",
+        "title": "Big Gigantic- Sky High"
+      },
+      {
+        "ytId": "p1JWpidoxSo",
+        "title": "This Moment- French Horn Rebellion"
+      }
+    ],
+    "Eurotrance": [
+      {
+        "ytId": "CUmze7jPiHA",
+        "title": "Sash! - Stay"
+      },
+      {
+        "ytId": "y6120QOlsfU",
+        "title": "Darude - Sandstorm"
+      },
+      {
+        "ytId": "wD0Mm6WIcYs",
+        "title": "Gigi D'Agostino - L'Amour Toujours"
+      },
+      {
+        "ytId": "IksRDCMYnn8",
+        "title": "Safri Duo - Played-A-Live"
+      },
+      {
+        "ytId": "X5S76oKO6NM",
+        "title": "Silence - Delirium ft Sarah Mclachlan"
+      },
+      {
+        "ytId": "MxwSbZMDhK8",
+        "title": "Ian van Dahl - Castles In The Sky "
+      },
+      {
+        "ytId": "RK-PAzu1Tmw",
+        "title": "Tina Cousins - Pray"
+      },
+      {
+        "ytId": "BF5bV6oWXJg",
+        "title": "Lasgo - Something   "
+      },
+      {
+        "ytId": "FA39yqwnX98",
+        "title": "Aurora ft. Naimee Coleman - Ordinary World"
+      },
+      {
+        "ytId": "ReqPNqp8v14",
+        "title": "Paul Van Dyk - Nothing But You"
+      },
+      {
+        "ytId": "uqEAD652ZS4",
+        "title": "The Mackenzie ft. Jessy - Innocence"
+      }
+    ],
+    "Progressive Trance": [
+      {
+        "ytId": "SDAm9WRomzU",
+        "title": "cm - dream universe"
+      },
+      {
+        "ytId": "vYO8jVDdpns",
+        "title": "Sasha - Xpander"
+      },
+      {
+        "ytId": "5WF-wqlz7_s",
+        "title": "Blue alphabet - Yellow evolution"
+      },
+      {
+        "ytId": "OFgQz7oZc_I",
+        "title": "BT - Nocturnal Transmission"
+      },
+      {
+        "ytId": "V4K78rzxOTc",
+        "title": "Moogwai - Viola"
+      },
+      {
+        "ytId": "ASh7z6eQUss",
+        "title": "T2 - 8-15 To Nowhere (DJ Taucher Remix)"
+      },
+      {
+        "ytId": "vB6rrwwqaXA",
+        "title": "Albion - Air"
+      },
+      {
+        "ytId": "kd9di4wp4g4",
+        "title": "Talla 2XLC Calls Moguai - Into Another (Moguai Clubmix)"
+      },
+      {
+        "ytId": "whz-_ZigUDc",
+        "title": "Lost Tribe - Gamemaster"
+      },
+      {
+        "ytId": "Rce8QnuFRVk",
+        "title": "PPK - Resurrection"
+      }
+    ],
+    "Detroit Techno": [
+      {
+        "ytId": "yxWzoYQb5gU",
+        "title": "Juan Atkins - Techno City"
+      },
+      {
+        "ytId": "sMq90UAg-Zw",
+        "title": "Derrick May - The Dance"
+      },
+      {
+        "ytId": "MV1B9S5Q6Bs",
+        "title": "Kevin Saunderson - Bassline"
+      },
+      {
+        "ytId": "8AQ193-u4Q8",
+        "title": "A Number Of Names - Sharevari "
+      },
+      {
+        "ytId": "cZFL2Ewo-oI",
+        "title": "Cybotron - Techno City (Instrumental)"
+      },
+      {
+        "ytId": "aPlRBcYC45Q",
+        "title": "Mad Mike - Hi-Tech Dreams"
+      },
+      {
+        "ytId": "HBbpxesIAHs",
+        "title": "Claude Young - Impolite To Refuse"
+      },
+      {
+        "ytId": "GwDuWU81-R8",
+        "title": "Rhythm Is Rhythm - Nude Photo"
+      },
+      {
+        "ytId": "j04_zmENtv8",
+        "title": "Anthony \"Shake\" Shakir - Soundblaster"
+      },
+      {
+        "ytId": "4WLtJDKXMCE",
+        "title": "Underground Resistance - The Final Frontier"
+      },
+      {
+        "ytId": "KevUFO2moZI",
+        "title": "Jeff Mills - The Bells"
+      },
+      {
+        "ytId": "0Mr0uNxXuIg",
+        "title": "Model 600 - Update (Version U.R.)"
+      }
+    ],
+    "Neo-Trance": [
+      {
+        "ytId": "t64m5Lm7CrA",
+        "title": "Trentemoller - Moan (Trentemoller Remix)"
+      },
+      {
+        "ytId": "Pe18N8U87YU",
+        "title": "Gui Boratto - No turning back"
+      },
+      {
+        "ytId": "b5zzS40-xbo",
+        "title": "James Holden - A Break In The Clouds"
+      },
+      {
+        "ytId": "d7zBePUZMog",
+        "title": "Nathan Fake - The Sky was Pink"
+      },
+      {
+        "ytId": "sdl7PZmlGQI",
+        "title": "Extrawelt - Soopertrack Original"
+      },
+      {
+        "ytId": "qaQKvA94GUo",
+        "title": "Dominik Eulberg - Der Tanz der Gluehwuermchen"
+      },
+      {
+        "ytId": "lQYfEpk9qMs",
+        "title": "Microtrauma - Diffusion"
+      },
+      {
+        "ytId": "lZHHmyFhp6M",
+        "title": "Popof- Serenity"
+      },
+      {
+        "ytId": "i77327EiOqg",
+        "title": "Shiva Chandra - Pieces"
+      }
+    ],
+    "Hi-NRG": [
+      {
+        "ytId": "J9yDoYRRBYY",
+        "title": "JX - Son of a Gun"
+      },
+      {
+        "ytId": "g8k0dbPLT3w",
+        "title": "X-Cabs - Neuro"
+      },
+      {
+        "ytId": "vtNv-pprhQ8",
+        "title": "FELIX - Don't You Want Me"
+      },
+      {
+        "ytId": "lb8nCaFF5yM",
+        "title": "Blu Peter - Magic"
+      },
+      {
+        "ytId": "b7xLMRbfxkk",
+        "title": "Commander Tom - Are Am Eye"
+      },
+      {
+        "ytId": "tz3OJMYwQBg",
+        "title": "EMBARGO! - EMBARGO!"
+      },
+      {
+        "ytId": "LTGxcO8C38Q",
+        "title": "Steve Thomas - Higher"
+      },
+      {
+        "ytId": "CYXAKmAXHzA",
+        "title": "Robert Armani - Hit Hard"
+      },
+      {
+        "ytId": "xdw4d12T_fU",
+        "title": "PUBLIC DOMAIN - Operation Blade (Bass In The Place...)"
+      },
+      {
+        "ytId": "QQT6uCBYa68",
+        "title": "Klubbheads - Hiphopping"
+      },
+      {
+        "ytId": "Mu0cE9RgK5M",
+        "title": "Dj Jean - The Launch"
+      },
+      {
+        "ytId": "sVOVWwQlCNw",
+        "title": "Porn kings - Up To No Good"
+      }
+    ],
+    "Freestyle / Breakdance": [
+      {
+        "ytId": "ymNFyxvIdaM",
+        "title": "Bomfunk MC's - Freestyler"
+      },
+      {
+        "ytId": "loOg5mIGHLY",
+        "title": "FLYING STEPS - Breakin' it Down"
+      },
+      {
+        "ytId": "m4EtLOvwW5w",
+        "title": "Music Instructor - Rock your body"
+      },
+      {
+        "ytId": "RRqmtPtl1Gs",
+        "title": "eXtatic - The Panic"
+      },
+      {
+        "ytId": "34gLCexf2mQ",
+        "title": "DJ M@R - Phaze Zero"
+      },
+      {
+        "ytId": "w5Yy4gS8kCc",
+        "title": "DJ Pablo - Battle Time"
+      },
+      {
+        "ytId": "3571XVYoTk4",
+        "title": "Kava - The Gambler"
+      },
+      {
+        "ytId": "vZMmk9l6zpU",
+        "title": "Mex - Way of the Exploding Crate"
+      },
+      {
+        "ytId": "Kc8A2x0H0VY",
+        "title": "Marc Hype - The Mexican"
+      },
+      {
+        "ytId": "Lp-xN-o6W90",
+        "title": "RJD2 - 1976"
+      },
+      {
+        "ytId": "N9viPN8XrBc",
+        "title": "Smoove - I'm A Man"
+      },
+      {
+        "ytId": "JTOnDzjVTKc",
+        "title": "Fader Gladiator & Das Lindenschmidt Orchechster - Beat Concerto"
+      }
+    ],
+    "Deep House": [
+      {
+        "ytId": "i5vnIX1niDQ",
+        "title": "Eddie Amador - House Music"
+      },
+      {
+        "ytId": "ik9cExHOazw",
+        "title": "Moodymann - I Can't Kick This Feeling When It Hits"
+      },
+      {
+        "ytId": "q_OPhLouIL4",
+        "title": "Fish Go Deep - Deep, Like"
+      },
+      {
+        "ytId": "UOC4VWQpnDM",
+        "title": "Gusto- Disco's revenge "
+      },
+      {
+        "ytId": "s_zPqWjDLwU",
+        "title": "Blue Six - Close to Home"
+      },
+      {
+        "ytId": "7-BnB3xxUoA",
+        "title": "Nightcrawlers - Push The Feeling On"
+      },
+      {
+        "ytId": "BxvBk_dSrKQ",
+        "title": "Move D - Jus House"
+      },
+      {
+        "ytId": "CsxJzW-0mAg",
+        "title": "Booka Shade vs MANDY - body language"
+      },
+      {
+        "ytId": "XpIrFglZfQU",
+        "title": "Leon Vynehall - It's Just"
+      },
+      {
+        "ytId": "UwPKi1H8t9M",
+        "title": "Jaydee-Plastic Dreams"
+      }
+    ],
+    "Florida Breaks": [
+      {
+        "ytId": "C7Okvrwtg6k",
+        "title": "Dynamix II - Just give the D.J. a break (Club Version)"
+      },
+      {
+        "ytId": "I10Tc2fnQhM",
+        "title": "DJ icey - Escape"
+      },
+      {
+        "ytId": "v5HEfbxk7Mw",
+        "title": "Planet Soul - Set U Free (Fever Mix)"
+      },
+      {
+        "ytId": "b4Spg-WNCiA",
+        "title": "DJ Baby Anne - Trippin' The Bass "
+      },
+      {
+        "ytId": "AnUEGrVy5eg",
+        "title": "Tony Faline - Feel The Funk"
+      },
+      {
+        "ytId": "4yMfEbisI-4",
+        "title": "Huda Hudia - C'mon Breakdown (Check This Out Mix)"
+      },
+      {
+        "ytId": "OetKuu-8erk",
+        "title": "Plump DJs - Eargasm - The Funk Hits The Fan"
+      },
+      {
+        "ytId": "qb-DhI3zIV8",
+        "title": "SOL BROTHERS - THAT ELVIS TRACK"
+      },
+      {
+        "ytId": "5dF0RldDSn0",
+        "title": "Lionrock - Rude Boy Rock"
+      }
+    ],
+    "Hip House / Eurodance": [
+      {
+        "ytId": "RkEXGgdqMz8",
+        "title": "2 Unlimited - No Limit"
+      },
+      {
+        "ytId": "mS1dAovhXOc",
+        "title": "Cappella - Move on baby"
+      },
+      {
+        "ytId": "Lk3lQRmIkoM",
+        "title": "2 Brothers on the 4th floor - Dreams (Will come alive)"
+      },
+      {
+        "ytId": "vUb_S4e-Rd4",
+        "title": "Snap - The Power"
+      },
+      {
+        "ytId": "7nE9xs2T1gs",
+        "title": "Dr. Alban - This Time I'm Free"
+      },
+      {
+        "ytId": "HEXWRTEbj1I",
+        "title": "Haddaway - What Is Love "
+      },
+      {
+        "ytId": "p3l7fgvrEKM",
+        "title": "GALA - Freed from desire"
+      },
+      {
+        "ytId": "ydd9Dn3bJlI",
+        "title": "La Bouche - Be My Lover"
+      },
+      {
+        "ytId": "u3ltZmI5LQw",
+        "title": "Corona - Rhythm of the Night"
+      },
+      {
+        "ytId": "dSy2DcATYUo",
+        "title": "Mo-Do - Eins Zwei Polizei"
+      },
+      {
+        "ytId": "2GV_5dRrWH4",
+        "title": "Leila K - Open Sesame"
+      },
+      {
+        "ytId": "dA0_6G_UOZM",
+        "title": "Technotronic - Hey Yoh, Here We Go"
+      }
+    ],
+    "Goa/PSY Trance": [
+      {
+        "ytId": "WVCsm0VIDcs",
+        "title": "Goa Gil - Acid Boom"
+      },
+      {
+        "ytId": "EwhhAj55HXQ",
+        "title": "Infected Mushroom - Bust a Move"
+      },
+      {
+        "ytId": "onquKz5SYRs",
+        "title": "ASTRAL PROJECTION - Mahadeva"
+      },
+      {
+        "ytId": "Yorq47lK-A0",
+        "title": "hallucinogen - Alpha Centauri."
+      },
+      {
+        "ytId": "vQpVAWFvkbU",
+        "title": "1200 Micrograms - LSD"
+      },
+      {
+        "ytId": "NqHfHSMmY-o",
+        "title": "s.u.n. project - dance of the witches"
+      },
+      {
+        "ytId": "M-In23SYcNM",
+        "title": "Spacetribe - You Can Be Shiva"
+      },
+      {
+        "ytId": "INYZs4kmnCk",
+        "title": "Talamasca - Overload"
+      },
+      {
+        "ytId": "ZEUi03k2Amk",
+        "title": "Space Buddha - Silent Galaxy"
+      },
+      {
+        "ytId": "2Ff2ojrCb4o",
+        "title": "Yahel Waves of Sound"
+      },
+      {
+        "ytId": "Thi2FXdFkfM",
+        "title": "Electric Universe - The Prayer"
+      }
+    ],
+    "Tech Trance": [
+      {
+        "ytId": "XYZ0J0MytIA",
+        "title": "Oliver Lieb - Parallax"
+      },
+      {
+        "ytId": "ynB-E722owE",
+        "title": "Humate - 3.1."
+      },
+      {
+        "ytId": "foxFjWKJXaE",
+        "title": "Marco V - Godd"
+      },
+      {
+        "ytId": "FtAqOUvsJi4",
+        "title": "Omnia - Jesselyn"
+      },
+      {
+        "ytId": "4yEDyEm186Q",
+        "title": "Megamind - Taub (Picotto Mix)"
+      },
+      {
+        "ytId": "2P0WfhUx3gY",
+        "title": "Ernesto vs Bastian - Who's the starter"
+      },
+      {
+        "ytId": "F6bWuO-KHy0",
+        "title": "timo maas - old school vibes"
+      },
+      {
+        "ytId": "ahntwzwwET0",
+        "title": "Beautiful Mind - Marcel Woods"
+      },
+      {
+        "ytId": "L5w9h6sR5x8",
+        "title": "Der Dritte Raum - Hale Bopp"
+      },
+      {
+        "ytId": "_6RDh5bEF4g",
+        "title": "Breeder - The Chain"
+      },
+      {
+        "ytId": "z7MXmcykwbk",
+        "title": "Ricky Le Roy - Metempsicosi"
+      }
+    ],
+    "Acid House": [
+      {
+        "ytId": "JCUPc9zVfyo",
+        "title": "Phuture - Acid Tracks"
+      },
+      {
+        "ytId": "aQUIsgrlp10",
+        "title": "MAURICE - This Is Acid"
+      },
+      {
+        "ytId": "lJnqRCwPeSw",
+        "title": "sleezy d - I ve lost control"
+      },
+      {
+        "ytId": "wXuQb8Ln6_g",
+        "title": "Chip E - Time to Jack"
+      },
+      {
+        "ytId": "emDEFtJIjy0",
+        "title": "A Guy Called Gerald - Voodoo Ray"
+      },
+      {
+        "ytId": "QMyxLbpxS6U",
+        "title": "D Mob - We Call It Acieed!"
+      },
+      {
+        "ytId": "QrHG0d_13tE",
+        "title": "Adonis - We're Rockin Down the House"
+      },
+      {
+        "ytId": "SpjnzxtZ6Qg",
+        "title": "The Shamen - Move any mountain"
+      },
+      {
+        "ytId": "j5IoLidzLH8",
+        "title": "Hit House Jack to the Sound of the Underground"
+      },
+      {
+        "ytId": "IpeRShWMdYM",
+        "title": "S'Express - Theme from S'Express"
+      },
+      {
+        "ytId": "W6CJmJ5p3Ow",
+        "title": "Bomb The Bass - Beat Dis"
+      }
+    ],
+    "Hardtrance": [
+      {
+        "ytId": "dVeCyaAccxY",
+        "title": "Komakino - Man on mars"
+      },
+      {
+        "ytId": "ZnBeTPpr98g",
+        "title": "Push - Universal Nation"
+      },
+      {
+        "ytId": "OonuVTc97cc",
+        "title": "RMB - Love Is An Ocean (Stephenson Remix)"
+      },
+      {
+        "ytId": "k5NJV1c6zmQ",
+        "title": "Central Seven - Missing"
+      },
+      {
+        "ytId": "6gHKECJYvr8",
+        "title": "Boccaccio Life - The secret wish"
+      },
+      {
+        "ytId": "jlwPNroYv1U",
+        "title": "Cosmic Gate - 'Firewire' "
+      },
+      {
+        "ytId": "pg0BLZszvHM",
+        "title": "Space Frog - X-Ray (Follow Me)"
+      },
+      {
+        "ytId": "xKgAqh8VA-k",
+        "title": "Trance Generators - Do U Wanna Balloon "
+      },
+      {
+        "ytId": "bxiqFV4Gf2U",
+        "title": "Brooklyn Bounce - Bass, Beats & Melody"
+      },
+      {
+        "ytId": "QEO3XbVGXA4",
+        "title": "lee haslam-music is the drug"
+      },
+      {
+        "ytId": "bMwH_66lxyk",
+        "title": "Blow Da Roof - Stimulant DJ's"
+      }
+    ],
+    "Hardstep": [
+      {
+        "ytId": "_SYvDRFSEd4",
+        "title": "Dieselboy 'Midnight Express'"
+      },
+      {
+        "ytId": "h0vS73yL6ys",
+        "title": "Evol Intent - Flipside"
+      },
+      {
+        "ytId": "o8DkdMJys7Y",
+        "title": "Ice minus - Babylon"
+      },
+      {
+        "ytId": "BMSp0b817aA",
+        "title": "ewun - guntalk"
+      },
+      {
+        "ytId": "AtbQYCvLtdk",
+        "title": "Dred Bass - Technology"
+      },
+      {
+        "ytId": "r6QR8A9_iFU",
+        "title": "Ed Rush & Optical - Chubrub"
+      },
+      {
+        "ytId": "rCky845gi3w",
+        "title": "Calyx & Teebee & Hive - Salvation"
+      },
+      {
+        "ytId": "-mfjV7j9m18",
+        "title": "Doc Scott - Michigan"
+      },
+      {
+        "ytId": "rS-58UV4vfY",
+        "title": "Capone - Tudor Rose"
+      },
+      {
+        "ytId": "KIGXGkzjAoc",
+        "title": "Bad Company - The Nine"
+      }
+    ],
+    "Intelligent Dance Music": [
+      {
+        "ytId": "7MBaEEODzU0",
+        "title": "Aphex Twin - Window Licker"
+      },
+      {
+        "ytId": "hfTAv8htci8",
+        "title": "Autechre - Nil"
+      },
+      {
+        "ytId": "-t1_cEUEYuo",
+        "title": "The Black Dog - Nommo"
+      },
+      {
+        "ytId": "se7w6pqBBxg",
+        "title": "Amon Tobin - Journeyman"
+      },
+      {
+        "ytId": "BL-0nC1vpmI",
+        "title": "LFO-Freak"
+      },
+      {
+        "ytId": "SqjZUyUtqYs",
+        "title": "Squarepusher - My Red Hot Car"
+      },
+      {
+        "ytId": "hniwkuYF7Cs",
+        "title": "Funckarma - Fuse"
+      },
+      {
+        "ytId": "gwDw2P0w-N4",
+        "title": "Bauri - Lakonia"
+      },
+      {
+        "ytId": "orG5TIOU8Ts",
+        "title": "Boards Of Canada - Telephasic Workshop"
+      }
+    ],
+    "Liquid Funk": [
+      {
+        "ytId": "elv-Egyp_To",
+        "title": "High Contrast - Racing Green"
+      },
+      {
+        "ytId": "v9RZ484qlIg",
+        "title": "London Elektricity - The Great Drum & Bass Swindle"
+      },
+      {
+        "ytId": "k7x51zWOBBs",
+        "title": "Utah Jazz - Take No More"
+      },
+      {
+        "ytId": "eBR11H2Hho8",
+        "title": "Logistics - Icarus (feat. Hugh Hardie)"
+      },
+      {
+        "ytId": "a6yAS__u2zE",
+        "title": "Marcus Intalex - Temperance [Soul:R]"
+      },
+      {
+        "ytId": "v3OzptqCDvw",
+        "title": "Calibre - Even If"
+      },
+      {
+        "ytId": "NiW-KG1pSpQ",
+        "title": "Q Project - Tears"
+      },
+      {
+        "ytId": "S85q2xSpwUI",
+        "title": "Drumsound and Bassline Smith - Through The Night (Ft. Tom Cane) "
+      },
+      {
+        "ytId": "M97vR2V4vTs",
+        "title": "Rudimental - Waiting All Night ft. Ella Eyre "
+      },
+      {
+        "ytId": "qFDP9egTwfM",
+        "title": "Netsky - Rio  ft. Digital Farm Animals"
+      },
+      {
+        "ytId": "ShNkIWWPvic",
+        "title": "J Majik & Wickaman - Crazy World feat. Kathy Brown"
+      },
+      {
+        "ytId": "tS26xch5U24",
+        "title": "Sigma & Rita Ora - Coming Home HD"
+      }
+    ],
+    "Hardcore Techno / Rave": [
+      {
+        "ytId": "-dohzrXT09w",
+        "title": "Human Resource - Dominator"
+      },
+      {
+        "ytId": "fQO5yeVJdaI",
+        "title": "The Hypnotist - Hardcore You Know The Score"
+      },
+      {
+        "ytId": "k3-uluEYsVw",
+        "title": "Channel X - Rave The Rhythm"
+      },
+      {
+        "ytId": "Mx3LccRvidg",
+        "title": "T99 - Anasthasia"
+      },
+      {
+        "ytId": "dN8e9b2ON8s",
+        "title": "L.A. STYLE - James Brown Is Dead"
+      },
+      {
+        "ytId": "w1xGbEDs6-4",
+        "title": "U96 - Das Boot MTV"
+      },
+      {
+        "ytId": "0PkD--DD0TM",
+        "title": "Quadrophonia - Quadrophonia"
+      },
+      {
+        "ytId": "LPtuEfYv0PE",
+        "title": "D-Shake - Techno Trance"
+      },
+      {
+        "ytId": "YLk8AMNCo24",
+        "title": "-APOTHEOSIS - O Fortuna"
+      },
+      {
+        "ytId": "fqgUOKsHFvQ",
+        "title": "Ace The Space - 9 Is A Classic"
+      },
+      {
+        "ytId": "gybB7HuC4gM",
+        "title": "LITTLE LITTLE - JUST THE WAY LIKE THIS"
+      },
+      {
+        "ytId": "qQxytJEhCI4",
+        "title": "Fierce Ruling Diva - Rubb it in"
+      }
+    ],
+    "New Beat": [
+      {
+        "ytId": "-FDy-RVeI-A",
+        "title": "A Split Second - Flesh"
+      },
+      {
+        "ytId": "HcbZUmLlNEo",
+        "title": "Lords of Acid - I Sit on Acid"
+      },
+      {
+        "ytId": "WpV-ItIqRTs",
+        "title": "Ibiza - Amnesia"
+      },
+      {
+        "ytId": "rAuoMZh8mVA",
+        "title": "DIRTY HARRY - D' BOP"
+      },
+      {
+        "ytId": "dLmyey_18TM",
+        "title": "Confetti's - The Sound Of C"
+      },
+      {
+        "ytId": "7vJJSXTfaTU",
+        "title": "Boytronic - Bryllyant"
+      },
+      {
+        "ytId": "_U3wbk7eOMw",
+        "title": "Fatal Error - Fatal Error"
+      },
+      {
+        "ytId": "zN-u2eJUVpc",
+        "title": "101 - Rock To The Beat (Club Mix)"
+      },
+      {
+        "ytId": "ARHsb-fAw4U",
+        "title": "Traxx - Malfunction"
+      },
+      {
+        "ytId": "6gGr8O40OXs",
+        "title": "CODE 61   Drop The Deal"
+      },
+      {
+        "ytId": "SDFDUbCOiD0",
+        "title": "In-D - Virgin s In-D Sky's"
+      }
+    ],
+    "Darkcore / Darkstep": [
+      {
+        "ytId": "I0KiAx6229A",
+        "title": "Grooverider - Where's Jack the Ripper"
+      },
+      {
+        "ytId": "DvOF4tpUzGs",
+        "title": "Kenny Ken - Project One"
+      },
+      {
+        "ytId": "9JISpdw5Pw8",
+        "title": "Jumping Jack Frost - Pornography"
+      },
+      {
+        "ytId": "fRKRNJPaFf8",
+        "title": "Randall & Andy C - Sound Control"
+      },
+      {
+        "ytId": "nyryDEPy4c8",
+        "title": "Mickey Finn - Reality"
+      },
+      {
+        "ytId": "fp9h9gszscQ",
+        "title": "Trace & Nico - Squadron"
+      },
+      {
+        "ytId": "JM07HYSGVho",
+        "title": "Pendulum - Blood Sugar"
+      },
+      {
+        "ytId": "SVwTF7Nw3-w",
+        "title": "Technical Itch - The Rukus"
+      },
+      {
+        "ytId": "CPed6Zqu0S4",
+        "title": "Dj Hidden-Chosen"
+      },
+      {
+        "ytId": "WW57nFRGVYI",
+        "title": "Rawthang - Unity"
+      }
+    ],
+    "UK Garage": [
+      {
+        "ytId": "WPmhmmeajW0",
+        "title": "Artful Dodger Feat. Craig David"
+      },
+      {
+        "ytId": "O1aaCEJ-x1g",
+        "title": "MJ Cole - Sincere"
+      },
+      {
+        "ytId": "OQCQnARnKbc",
+        "title": "Shanks & Bigfoot - Sweet Like Chocolate"
+      },
+      {
+        "ytId": "VVycT8k0tjM",
+        "title": "2 Step /Groove Chronicles - Stone Cold"
+      },
+      {
+        "ytId": "F5PXdScoOrg",
+        "title": "Dj Luck & MC Neat - A Little Bit Of Luck "
+      },
+      {
+        "ytId": "94K9oK1YM1o",
+        "title": "T2 feat. Jodie - Heartbroken (Wideboys London Mix)"
+      },
+      {
+        "ytId": "g7VhofoV3qs",
+        "title": "So Solid Crew - 21 Seconds "
+      },
+      {
+        "ytId": "LicesW1G55o",
+        "title": "tuff jam & todd edwards - wanting Jesus"
+      },
+      {
+        "ytId": "lvVIyKHXJ9U",
+        "title": "UK Garage - Amira - My Desire (Dreem Teem Remix)"
+      },
+      {
+        "ytId": "uR3Vw8J8vUo",
+        "title": "Double 99 - RIP Groove"
+      },
+      {
+        "ytId": "jiXdKVitp6o",
+        "title": "Smokin Beats - Dreams - Feat Lyn Eden "
+      },
+      {
+        "ytId": "jYNVY_Yu1cs",
+        "title": "Scott Garcia Ft MC Styles - A London Thing"
+      }
+    ],
+    "Grime": [
+      {
+        "ytId": "ISy0Hl0SBfg",
+        "title": "Dizzee Rascal - Bonkers"
+      },
+      {
+        "ytId": "HK1SpAy_cR4",
+        "title": "Roll Deep \"When I'm Ere\" music video"
+      },
+      {
+        "ytId": "p48icgIs4sI",
+        "title": "Lady Sovereign - Blah Blah"
+      },
+      {
+        "ytId": "mO3dl25gR_g",
+        "title": "Wiley - Eskimo"
+      },
+      {
+        "ytId": "YNiYjYdOzOA",
+        "title": "The Bug - 'Function' ft Manga"
+      },
+      {
+        "ytId": "WB6W4wQDPCw",
+        "title": "Musical Mob - Iron"
+      },
+      {
+        "ytId": "m9nG_uctAkw",
+        "title": "Jammer Ft. Wiley, D Double E, Kano & Durrty Goodz - Destruction V.I.P"
+      },
+      {
+        "ytId": "czBPOwSZVys",
+        "title": "Skepta - Man"
+      },
+      {
+        "ytId": "5-s32ESIR-4",
+        "title": "Deekline - I Don't Smoke "
+      },
+      {
+        "ytId": "2nRUrCEuYi0",
+        "title": "Stanton Warriors - MPC "
+      },
+      {
+        "ytId": "j3xUloTrYA0",
+        "title": "CHIPMUNK X STORMZY - HEAR DIS"
+      }
+    ],
+    "Ambient Braks / Illbient": [
+      {
+        "ytId": "FAYHTES4whs",
+        "title": "Moby - Porcelain"
+      },
+      {
+        "ytId": "sGjfLuVn44Q",
+        "title": "Apollo 440 - Electro Glide In Blue"
+      },
+      {
+        "ytId": "TwDOa-lvizM",
+        "title": "Nightmares on Wax - You Wish"
+      },
+      {
+        "ytId": "5-wl7Xk5FoY",
+        "title": "Coldcut - Timber"
+      },
+      {
+        "ytId": "MpMC2_SCY7w",
+        "title": "Hexstatic - 'Ninja Tune'"
+      },
+      {
+        "ytId": "y2Eah_EGiDc",
+        "title": "Blue Boy - Remember Me "
+      },
+      {
+        "ytId": "3IWl77o3l50",
+        "title": "Bentley Rhythym Ace - Bentley's Gonna Sort You Out"
+      },
+      {
+        "ytId": "rLMXRYjZgvs",
+        "title": "Utah Saints - B777"
+      },
+      {
+        "ytId": "8ePgkZ6diEY",
+        "title": "Teargas and Plateglass - Arkhangelsk"
+      },
+      {
+        "ytId": "N7eDIgsQiG0",
+        "title": "DJ Spooky - Anansi Abstrakt"
+      },
+      {
+        "ytId": "D7wuSg14eCs",
+        "title": "Witchman - Chemical Noir"
+      }
+    ],
+    "Intelligent DnB / Jazzstep": [
+      {
+        "ytId": "ZNO7-OYLI9U",
+        "title": "Alex Reece - Pulp Fiction"
+      },
+      {
+        "ytId": "1ETABpY20oo",
+        "title": "Kruder & Dorfmeister  - Speechless"
+      },
+      {
+        "ytId": "a5meT63flnM",
+        "title": "Origin Unknown - Valley Of The Shadows"
+      },
+      {
+        "ytId": "aJMZsgDCl4o",
+        "title": "Roni Size - It's A Jazz Thing"
+      },
+      {
+        "ytId": "8ifeoU79b5A",
+        "title": "E-Z Rollers - Walk This Land"
+      },
+      {
+        "ytId": "7mekSjaYy0c",
+        "title": "LTJ Bukem - Inner Guidance"
+      },
+      {
+        "ytId": "d3VmSvN1mts",
+        "title": "Omni Trio - Secret Life"
+      },
+      {
+        "ytId": "ekbHXNyEnU4",
+        "title": "45Roller* ‎– Saturday Night Roller"
+      },
+      {
+        "ytId": "d9jVW1x_Ris",
+        "title": "DJ Trace - Miles High"
+      }
+    ],
+    "Neurofunk": [
+      {
+        "ytId": "xtppf3xkby4",
+        "title": "Noisia - Stigma"
+      },
+      {
+        "ytId": "8UAUDbWrVhA",
+        "title": "Konflict - Messiah"
+      },
+      {
+        "ytId": "BE6wt300Vfw",
+        "title": "Black Sun Empire - Breach"
+      },
+      {
+        "ytId": "nwkzDNU5B2Q",
+        "title": "Ram Trilogy - Titan"
+      },
+      {
+        "ytId": "gMlr-mMMYTc",
+        "title": "Decoder & Ice Minus - Drowning"
+      },
+      {
+        "ytId": "nkldv7k3tC8",
+        "title": "Usual Suspects - Killa Bees"
+      },
+      {
+        "ytId": "_reElm4cPOY",
+        "title": "Apache - Matrix"
+      },
+      {
+        "ytId": "mqLZeU1u4UY",
+        "title": "The Qemists - Lost Weekend (I Got Your Money)"
+      },
+      {
+        "ytId": "uyn7pf3ELGc",
+        "title": "Signs - Plasma"
+      },
+      {
+        "ytId": "PX8I8vVhF2M",
+        "title": "Trei - Backburner"
+      }
+    ],
+    "Ibiza/Dream House": [
+      {
+        "ytId": "zI7DferroGA",
+        "title": "Robert Miles Children"
+      },
+      {
+        "ytId": "lpkLcfbOra4",
+        "title": "BBE - 7 days and one week"
+      },
+      {
+        "ytId": "G9-1r1d0Hyo",
+        "title": "Zhi-Vago - Celebrate (The Love)"
+      },
+      {
+        "ytId": "kYwRXqjiAZ8",
+        "title": "DJ Dado - X-Files"
+      },
+      {
+        "ytId": "EyBsoG8UWmc",
+        "title": "W P - ALEX REMARK - Pyramid (In Dream)"
+      },
+      {
+        "ytId": "9o2cV-FpoHo",
+        "title": "Cafe Del Mar - Energy 52"
+      },
+      {
+        "ytId": "ltpCS5P0zCw",
+        "title": "Chicane - Offshore"
+      },
+      {
+        "ytId": "LTERifplFcM",
+        "title": "Sunlounger - Sunkissed "
+      },
+      {
+        "ytId": "2QAlaBcWC5o",
+        "title": "Nalin & Kane - Beachball"
+      },
+      {
+        "ytId": "Y0ye9oFD1vE",
+        "title": "Miro - Emotions of Paradise"
+      }
+    ],
+    "(free)tek(k)no": [
+      {
+        "ytId": "gdvweWe6ACg",
+        "title": "Spiral Tribe - FFWD THE REVOLUTION"
+      },
+      {
+        "ytId": "UVYuNEQdIKc",
+        "title": "69db - OrnOrm"
+      },
+      {
+        "ytId": "gcnyPy32WRQ",
+        "title": "Crystal Distortion - Power to the Pipe"
+      },
+      {
+        "ytId": "JHSiuaO_09c",
+        "title": "Jack acid - acid tension"
+      },
+      {
+        "ytId": "DAfntnwU3bo",
+        "title": "SuBuRbASs - Yes PaPaRoubek"
+      },
+      {
+        "ytId": "JMoUwIOKhwc",
+        "title": "Mala (Addictik) - La Mescalina"
+      },
+      {
+        "ytId": "FrEADHbX5fE",
+        "title": "Kaos - 23 aera"
+      },
+      {
+        "ytId": "tKwjrv-ivow",
+        "title": "Heretik - Beuns-Game Over"
+      },
+      {
+        "ytId": "tQ_ylWgiRqA",
+        "title": "Metek Sound System - Metek Style"
+      }
+    ],
+    "Moombahton": [
+      {
+        "ytId": "KkqX2h99OXY",
+        "title": "Dave Nada - Moombahton"
+      },
+      {
+        "ytId": "e7eZUGB9HKU",
+        "title": "Major Lazer - Light It Up (feat. Nyla & Fuse ODG)"
+      },
+      {
+        "ytId": "EUD39sJUue8",
+        "title": "Diplo & GTA - Boy Oh Boy"
+      },
+      {
+        "ytId": "X-8VeSDgAgg",
+        "title": "Ape Drums - Bashment"
+      },
+      {
+        "ytId": "3ArOBAt5Ml0",
+        "title": "Dillon Francis, Skrillex - Bun Up the Dance"
+      },
+      {
+        "ytId": "LPTa7Fq2T1M",
+        "title": "Tropkillaz - Que Passa Amigo"
+      },
+      {
+        "ytId": "YzMdE2tcERU",
+        "title": "Munchi - La Brasileña Ta Montao (feat. Angel Doze)"
+      },
+      {
+        "ytId": "3pVxWok4iLA",
+        "title": "Torro Torro & Long Jawns - The Pump"
+      },
+      {
+        "ytId": "u9ESD5M5pBQ",
+        "title": "ETC!ETC!: Temblando"
+      },
+      {
+        "ytId": "LII5vsz7niY",
+        "title": "Jesse Slayter - Thick"
+      },
+      {
+        "ytId": "UwsR5LC0mII",
+        "title": "[Gelöschtes Video]"
+      }
+    ],
+    "Dubstep": [
+      {
+        "ytId": "KandVSZbZAM",
+        "title": "Skream - Exothermic Reaction"
+      },
+      {
+        "ytId": "VIpnaZMa4Yg",
+        "title": "Burial: Southern Comfort"
+      },
+      {
+        "ytId": "-udpkxPnMRY",
+        "title": "Kode9 - Black Sun"
+      },
+      {
+        "ytId": "jVKboRPgu0U",
+        "title": "Benga - Crunked Up"
+      },
+      {
+        "ytId": "QrRcEfulv3U",
+        "title": "Digital Mystikz - Earth A Run Red"
+      },
+      {
+        "ytId": "Ky5Mt2PLf9E",
+        "title": "Dubstep - Mala - Changes"
+      },
+      {
+        "ytId": "Fbi7Y5NysYs",
+        "title": "Loefah - The Goat Stare"
+      },
+      {
+        "ytId": "nVVCDneVxm8",
+        "title": "Caspa & Rusko - Blouse an Skirt"
+      },
+      {
+        "ytId": "43XLXmx5tQ0",
+        "title": "Vex'd - Corridor"
+      },
+      {
+        "ytId": "7280__uzZus",
+        "title": "MRK1 - Grit"
+      },
+      {
+        "ytId": "yEpuq51ncNk",
+        "title": "Distance - V"
+      }
+    ],
+    "Chemical Breaks": [
+      {
+        "ytId": "TguJjg-p2mE",
+        "title": "The Chemical Brothers - Chemical Beats"
+      },
+      {
+        "ytId": "ht7FQX3zpqQ",
+        "title": "Fluke - Absurd"
+      },
+      {
+        "ytId": "2C0jyGwxUZk",
+        "title": "The Crystal Method - Comin` Back"
+      },
+      {
+        "ytId": "SP6cmVZbJJU",
+        "title": "The Prodigy - Smack My Bitch Up"
+      },
+      {
+        "ytId": "F7jSp2xmmEE",
+        "title": "Fatboy Slim - Right Here Right Now"
+      },
+      {
+        "ytId": "jaI7PDSRELY",
+        "title": "Overseer - Basstrap"
+      },
+      {
+        "ytId": "fCkKx5B8OK4",
+        "title": "Junkie xl- Billy Club"
+      },
+      {
+        "ytId": "maP6q3D4Hf0",
+        "title": "Lunatic Calm - Leave You Far Behind"
+      },
+      {
+        "ytId": "XGYjxiGsy8g",
+        "title": "Andy Hunter - Come On"
+      },
+      {
+        "ytId": "AFn-Wr3qDTY",
+        "title": "07 We Got The Gun"
+      },
+      {
+        "ytId": "xIXCVZ9evuo",
+        "title": "PropellerHeads - SpyBreak!"
+      },
+      {
+        "ytId": "auWbz0atKXE",
+        "title": "Eboman - Donuts with Buddha"
+      }
+    ],
+    "Progresssive House": [
+      {
+        "ytId": "F6Y7lcvubhU",
+        "title": "Underworld - Rez"
+      },
+      {
+        "ytId": "8D56eqR-qiM",
+        "title": "Leftfield - Afro - Left"
+      },
+      {
+        "ytId": "7rw4S3jqqz4",
+        "title": "The Aloof - Bittersweet"
+      },
+      {
+        "ytId": "zzHmXaUSL6o",
+        "title": "Bedrock Feat. KYO - For What You Dream Of"
+      },
+      {
+        "ytId": "tDRtjooGe1I",
+        "title": "Spooky - Don't Panic"
+      },
+      {
+        "ytId": "GTYTJ807wS0",
+        "title": "Austin Leeds - Force 51"
+      },
+      {
+        "ytId": "V7aELkYPIXA",
+        "title": "Cass - Emotion Surfer "
+      },
+      {
+        "ytId": "ryIM3EUE6nI",
+        "title": "Rhythm Reigns - Fuel "
+      },
+      {
+        "ytId": "ipaqnOeKsDA",
+        "title": "Poseidon - Supertransonic (Timo Maas Mix)"
+      },
+      {
+        "ytId": "szbxT0QDqn8",
+        "title": "Mara- Desanitize (Fakkindaddydub)"
+      }
+    ],
+    "Trapstep / EDM Trap": [
+      {
+        "ytId": "6HzyUHxmkg0",
+        "title": "TNGHT - Higher Ground (Hudson Mohawke x Lunice)"
+      },
+      {
+        "ytId": "qV0LHCHf-pE",
+        "title": "Baauer - Harlem Shake"
+      },
+      {
+        "ytId": "KNByf1o4T_8",
+        "title": "Flosstradamus feat. Casino - Mosh Pit"
+      },
+      {
+        "ytId": "oIwFJNguQgY",
+        "title": "Yellow Claw - Shotgun ft. Rochelle"
+      },
+      {
+        "ytId": "Kz1CqHw35Bs",
+        "title": "RL Grime - Scylla"
+      },
+      {
+        "ytId": "mUiEqZDPIXY",
+        "title": "UZ - Trap Shit V17"
+      },
+      {
+        "ytId": "Ya_XddpkeJ8",
+        "title": "Bro Safari feat. DJ Craze - Spooked"
+      },
+      {
+        "ytId": "Zk7Dg30tCDU",
+        "title": "TroyBoi - Afterhours (feat. Diplo & Nina Sky)"
+      },
+      {
+        "ytId": "k_MWuP2Qj7U",
+        "title": "Hudson Mohawke - Chimes"
+      },
+      {
+        "ytId": "3FPwcaflCS8",
+        "title": "Aero Chord - Surface"
+      },
+      {
+        "ytId": "Io0fBr1XBUA",
+        "title": "The Chainsmokers - Don't Let Me Down ft. Daya"
+      }
+    ],
+    "Future Garage/Bass": [
+      {
+        "ytId": "HdzI-191xhU",
+        "title": "ODESZA - Say My Name (feat. Zyra)"
+      },
+      {
+        "ytId": "Ly7uj0JwgKg",
+        "title": "Flume - Never Be Like You feat. Kai"
+      },
+      {
+        "ytId": "_pABewcNigQ",
+        "title": "Manila Killa - All That's Left feat. Joni Fatora"
+      },
+      {
+        "ytId": "0zrAuAM2DEw",
+        "title": "Bearson - Want You (feat. Cal)"
+      },
+      {
+        "ytId": "i9bmuOl7QN4",
+        "title": "Mazde - Battas (feat. LissA)"
+      },
+      {
+        "ytId": "AQI0RTXwmjY",
+        "title": "Cashmere Cat - Rice Rain"
+      },
+      {
+        "ytId": "n4yu_oUM9TU",
+        "title": "Wave Racer - Streamers"
+      },
+      {
+        "ytId": "1_WeBcBeuWU",
+        "title": "LIDO - MONEY "
+      },
+      {
+        "ytId": "sOYd7AEoMtI",
+        "title": "XXYYXX - Echo Volture"
+      },
+      {
+        "ytId": "rI-t2M0t63s",
+        "title": "[Future Bass] - Kasbo - Kaleidoscope"
+      }
+    ],
+    "Epic Trance": [
+      {
+        "ytId": "8tIgN7eICn4",
+        "title": "DJ Tiesto - Adagio For Strings"
+      },
+      {
+        "ytId": "gTPSxbQ9sbo",
+        "title": "Rank 1 - Airwave "
+      },
+      {
+        "ytId": "QKwK-ZhTurg",
+        "title": "Binary Finary - 1998 "
+      },
+      {
+        "ytId": "WdGwqUtJ03o",
+        "title": "Ferry Corsten - Beautiful"
+      },
+      {
+        "ytId": "paSm1qTy9yg",
+        "title": "Svenson & Gielen - The Beauty Of Silence"
+      },
+      {
+        "ytId": "Q2C2V3kac08",
+        "title": "Armin van Buuren feat. Kensington - Heading Up High"
+      },
+      {
+        "ytId": "8JppHhLYEvM",
+        "title": "Cygnus X - Superstring"
+      },
+      {
+        "ytId": "XHKImaLHkns",
+        "title": "System F - Dance Valley Theme 2001 "
+      },
+      {
+        "ytId": "aGlEJEXDJj8",
+        "title": "Dash Berlin - Feel U Here"
+      },
+      {
+        "ytId": "amRzeWrbAq8",
+        "title": "DJ Tatana ft. Energy - End of Time"
+      },
+      {
+        "ytId": "3-UizNvummY",
+        "title": "Members of Mayday - 10 in 01"
+      }
+    ],
+    "Industrial techno": [
+      {
+        "ytId": "fSwI2AFlki4",
+        "title": "Joey Beltram - Energy Flash "
+      },
+      {
+        "ytId": "eZlARaT5_3w",
+        "title": "Mescalinum United - We Have Arrived"
+      },
+      {
+        "ytId": "sq1ZYSuEnu8",
+        "title": "Richie Hawtin - Minus / Orange 1"
+      },
+      {
+        "ytId": "CfAzcz33PyE",
+        "title": "Dave Clarke - The Storm (Red Three)"
+      },
+      {
+        "ytId": "WflVHf43E40",
+        "title": "Planetary Assault Systems - Rip The Cut"
+      },
+      {
+        "ytId": "VzhAyLlJxT0",
+        "title": "DJ Hell - Three Degrees Kelvin"
+      },
+      {
+        "ytId": "q49Bn9xibQI",
+        "title": "Chris Liebing - Gassenhauer"
+      },
+      {
+        "ytId": "Qx1lfuc7qVM",
+        "title": "Johannes Heil Paranoid Dancer"
+      },
+      {
+        "ytId": "-D9tNCEe9ek",
+        "title": "CODE INDUSTRY - FURY"
+      },
+      {
+        "ytId": "gZHZQ-RWaBU",
+        "title": "Oliver Klitzing - I Like That Beat"
+      },
+      {
+        "ytId": "Hrw0IIKrrFM",
+        "title": "Sven Wittekind - Darkness All Night"
+      }
+    ],
+    "Broken Beats": [
+      {
+        "ytId": "QZUFbKKVAdU",
+        "title": "IG Culture - Girl U Need A Change Of Mind"
+      },
+      {
+        "ytId": "XUpDHVInXCs",
+        "title": "Domu - Unfazed"
+      },
+      {
+        "ytId": "mtjg6MIl52M",
+        "title": "Bugz In The Attic -  It Don't Work Like That"
+      },
+      {
+        "ytId": "8iNzHHwt2zI",
+        "title": "Volcov - Sweet Love"
+      },
+      {
+        "ytId": "SSJXkizPABs",
+        "title": "Modaji ft. Jag - No Disguise"
+      },
+      {
+        "ytId": "nQkSRybhPTk",
+        "title": "Afronaught - Transcend Me"
+      },
+      {
+        "ytId": "Ju3UiYuK1s4",
+        "title": "neon phusion - timeless motion"
+      },
+      {
+        "ytId": "cUu6y35I9us",
+        "title": "Vikter Duplaix - Make A Baby "
+      },
+      {
+        "ytId": "ls1FRm48v8Y",
+        "title": "NEW SECTOR MOVEMENTS - Groove Now"
+      }
+    ],
+    "Digital Hardcore": [
+      {
+        "ytId": "_fX4qoruQik",
+        "title": "Venetian Snares - Szamar madar"
+      },
+      {
+        "ytId": "0X34Lgmz8PI",
+        "title": "Bong-Ra '666MPH'"
+      },
+      {
+        "ytId": "CPzVWlcefh0",
+        "title": "V/Vm - sabam"
+      },
+      {
+        "ytId": "_qAEdi68caM",
+        "title": "Speedranch vs End - Tea"
+      },
+      {
+        "ytId": "MKp30C3MwVk",
+        "title": "Igorrr - Tout Petit Moineau"
+      },
+      {
+        "ytId": "QzvRShWU8No",
+        "title": "Atari Teenage Riot - Sick to Death"
+      },
+      {
+        "ytId": "aJP7QJ1IPIg",
+        "title": "Ec8or - Dynamite"
+      },
+      {
+        "ytId": "8np68opO93Y",
+        "title": "SHIZUO - SWEAT"
+      },
+      {
+        "ytId": "YLDEbd1HCUM",
+        "title": "Bomb 20 - Burn the shit down!"
+      },
+      {
+        "ytId": "OnmbG-kzyHo",
+        "title": "Panacea - Found A Lover"
+      }
+    ],
+    "UK Funky / Bassline": [
+      {
+        "ytId": "fXAnXT8Hm2A",
+        "title": "Dexplicit Ft. Lauren Mason- Not your baby (DJ Q special)"
+      },
+      {
+        "ytId": "WTsHWzvJWDQ",
+        "title": "T2 - Heartbroken (Ft. Jodie)"
+      },
+      {
+        "ytId": "ncs57OkTIxM",
+        "title": "Smasher - Watch Your Back"
+      },
+      {
+        "ytId": "hqFRq1xlOOg",
+        "title": "TS7 - Heartlight (Ft. Taylor Fowlis) "
+      },
+      {
+        "ytId": "84QaqN0zayk",
+        "title": "SUPA D - SHAKE LOOSE"
+      },
+      {
+        "ytId": "1Mhi0RfXHx4",
+        "title": "Karizma -  Rock Away"
+      },
+      {
+        "ytId": "s1jp94Psx18",
+        "title": "Mosca - Bax"
+      },
+      {
+        "ytId": "Dhi8CLnk96M",
+        "title": "Omar & Zed Bias - Dancing"
+      }
+    ],
+    "Post- Dubstep": [
+      {
+        "ytId": "YJVmu6yttiw",
+        "title": "SKRILLEX - Bangarang feat. Sirah"
+      },
+      {
+        "ytId": "OanbqQP2hBY",
+        "title": "Datsik - Firepower"
+      },
+      {
+        "ytId": "mjKzV9gl490",
+        "title": "EXCISION - Brutal "
+      },
+      {
+        "ytId": "30ScfAfEBJg",
+        "title": "Noisestorm - Breakdown"
+      },
+      {
+        "ytId": "EwDIs6zTBeA",
+        "title": "[Drumstep] - Feint - Formless"
+      },
+      {
+        "ytId": "VUnjBY7NIso",
+        "title": "Detzky - Shadow Dance"
+      },
+      {
+        "ytId": "24RbLt2qGfY",
+        "title": "Au5 & Fractal - Smoke"
+      },
+      {
+        "ytId": "z5hALgSaSIo",
+        "title": "Vonikk - Superstar"
+      },
+      {
+        "ytId": "m0psosrTuas",
+        "title": "Gramatik - So Much For Love "
+      }
+    ],
+    "Trancecore / Acidcore": [
+      {
+        "ytId": "-xLEYF25bHs",
+        "title": "Sharkey & Eclipse- The Warning"
+      },
+      {
+        "ytId": "Ph5Ag_jzm0w",
+        "title": "Bass-X vs Scott Brown - Pilgrim (Version 2000)"
+      },
+      {
+        "ytId": "4phIs_1yRLg",
+        "title": "Scott Majestik - Acid Dreams"
+      },
+      {
+        "ytId": "S3YhxLHhvpg",
+        "title": "Kaos & Ethos — Lost"
+      },
+      {
+        "ytId": "f00Ys9G6JyY",
+        "title": "Brisk & Trixxy- Back To The Top"
+      },
+      {
+        "ytId": "GI6EOQ0Zuq8",
+        "title": "Dj Buzz Fuzz - Frequencies"
+      },
+      {
+        "ytId": "FVgskJ6ND58",
+        "title": "Mr. Gasmask - Jawbreaker"
+      },
+      {
+        "ytId": "CrA_D8Vlj7c",
+        "title": "Cellblock-X - Return Of Spoo"
+      },
+      {
+        "ytId": "0C9Ly2mjnQ8",
+        "title": "Pzylo - X-trabass"
+      },
+      {
+        "ytId": "IczFLXmVoJU",
+        "title": "Acidolido - Sabotage"
+      }
+    ],
+    "Glitch Hop": [
+      {
+        "ytId": "Zjp2HUY7dQY",
+        "title": "Antipop Consortium - Ghostlawns"
+      },
+      {
+        "ytId": "poEKWbLO9aU",
+        "title": "Push Button Objects - 360 Degrees ft Mr Lif, Del & DJ Craze"
+      },
+      {
+        "ytId": "fJY7BMzx7Iw",
+        "title": "Prefuse 73 - Perverted Undertone"
+      },
+      {
+        "ytId": "j81fYZVvFh4",
+        "title": "edIT Ants"
+      },
+      {
+        "ytId": "H-k_Eg7zXuc",
+        "title": "The Glitch Mob - We Can Make The World Stop"
+      },
+      {
+        "ytId": "Sk9XYQMRiLY",
+        "title": "Pretty Lights - Finally Moving"
+      },
+      {
+        "ytId": "st75F4Wy7oM",
+        "title": "Rustie - First Mythz "
+      },
+      {
+        "ytId": "CESYvCI66rY",
+        "title": "Funkstörung - Grammy Winners"
+      },
+      {
+        "ytId": "Aclft-KytMI",
+        "title": "Dabrye ft MF Doom - Air"
+      }
+    ],
+    "Fidget House / Complextro": [
+      {
+        "ytId": "YcVPnX-nML4",
+        "title": "Kid Cudi - Day 'N' Nite (Crookers Remix)"
+      },
+      {
+        "ytId": "VABjk9mxU2k",
+        "title": "Hervé - Together"
+      },
+      {
+        "ytId": "Z3fh-yZSWoU",
+        "title": "Jack Beats - Get Down "
+      },
+      {
+        "ytId": "iODdvJGpfIA",
+        "title": "Fake Blood - Mars "
+      },
+      {
+        "ytId": "PRqRTtyKPMg",
+        "title": "AC Slater - U Got 2"
+      },
+      {
+        "ytId": "CWXFhyQy2Xc",
+        "title": "Mord Fustang - Elite Beat Agent"
+      },
+      {
+        "ytId": "PPwCmhvmHeM",
+        "title": "Huoratron - $$ Troopers"
+      },
+      {
+        "ytId": "OkvXO45XL-c",
+        "title": "Wolfgang Gartner - Undertaker"
+      },
+      {
+        "ytId": "7eZIbmq5Jiw",
+        "title": "[Electro House] Virtual Riot - Energy Drink"
+      }
+    ],
+    "Nu Skool Breaks": [
+      {
+        "ytId": "_WTBkj8gFfI",
+        "title": "ADAM FREELAND - WE WANT YOUR SOUL"
+      },
+      {
+        "ytId": "CI8DW1Z-PNU",
+        "title": "Koma & Bones - Morpheus "
+      },
+      {
+        "ytId": "IoGKgpLi9J0",
+        "title": "Rennie Pilgrem - Paranoia"
+      },
+      {
+        "ytId": "-LxAxQQNn2U",
+        "title": "Tayo - Fire Good"
+      },
+      {
+        "ytId": "A1Ici26u__4",
+        "title": "Friction & Spice - You Make Me Feel So Good"
+      },
+      {
+        "ytId": "7B4S3AC5j_c",
+        "title": "Ils Revolver"
+      },
+      {
+        "ytId": "wr2o8qqc-1Y",
+        "title": "PMT - Gyromancer"
+      },
+      {
+        "ytId": "AcICrHac3z4",
+        "title": "Freq Nasty - Goose"
+      },
+      {
+        "ytId": "ajYUU606G1w",
+        "title": "Digital Witchcraft - Snowday"
+      },
+      {
+        "ytId": "NJrmm5P5WSw",
+        "title": "Hybrid - Just For Today"
+      },
+      {
+        "ytId": "sXqYvy10Mbg",
+        "title": "Momu - Donner Pass "
+      }
+    ],
+    "Electro": [
+      {
+        "ytId": "9lDCYjb8RHk",
+        "title": "Soul Sonic Force - Planet Rock"
+      },
+      {
+        "ytId": "bGd_HkpVaJs",
+        "title": "Arabian Prince & The Sheiks  - Situation Hot"
+      },
+      {
+        "ytId": "L4472HNKXDI",
+        "title": "C.O.D. - In The Bottle"
+      },
+      {
+        "ytId": "-9fjN5lUgYo",
+        "title": "Whodini - Magic's Wand"
+      },
+      {
+        "ytId": "7VaGGZplMPs",
+        "title": "Tyrone Brunson - The Smurf"
+      },
+      {
+        "ytId": "73omlAllMm4",
+        "title": "Bassline - Mantronix"
+      },
+      {
+        "ytId": "qjFs9CPGhts",
+        "title": "The Egyptian Lover - Egypt, Egypt"
+      },
+      {
+        "ytId": "qPpa5gs536Y",
+        "title": "The Jonzun Crew-Pack Jam"
+      },
+      {
+        "ytId": "ykK0uEjSsqY",
+        "title": "Hashim - Al-Naafiysh (The Soul)"
+      },
+      {
+        "ytId": "xDj54ZdJw_w",
+        "title": "Twilight 22 - Electric Kingdom"
+      },
+      {
+        "ytId": "r0L_AVc1OjE",
+        "title": "Man Parish - Boogie Down Bronx"
+      }
+    ],
+    "Classic Trance": [
+      {
+        "ytId": "30eXKMfrVcw",
+        "title": "The Age Of Love - The Age Of Love"
+      },
+      {
+        "ytId": "FJjD6BVGeGQ",
+        "title": "Cosmic Baby - The Space Track"
+      },
+      {
+        "ytId": "5A9OIIapSko",
+        "title": "ATB - 9PM (Till I Come) -"
+      },
+      {
+        "ytId": "8Eq0i187kvE",
+        "title": "Stella - Jam and Spoon"
+      },
+      {
+        "ytId": "ZKKoXgrDMPM",
+        "title": "Dance 2 Trance - Power Of American Natives"
+      },
+      {
+        "ytId": "2l7wW7FLnbY",
+        "title": "Resistance D - Throm"
+      },
+      {
+        "ytId": "Z7Gn1ZuNd6Q",
+        "title": "Electric Skychurch - \"Deus\""
+      },
+      {
+        "ytId": "S6ruUooMK9w",
+        "title": "Hardfloor - Acperience 1_video_edit "
+      },
+      {
+        "ytId": "YXwdMYEPjCU",
+        "title": "Art Of Trance - Kaleidoscope"
+      }
+    ],
+    "Dutch House": [
+      {
+        "ytId": "10pmPiK8pi8",
+        "title": "Fedde Le Grand - Put Your Hands Up 4 Detroit"
+      },
+      {
+        "ytId": "a0fkNdPIIL4",
+        "title": "Benny Benassi - Satisfaction"
+      },
+      {
+        "ytId": "PkQ5rEJaTmk",
+        "title": "Swedish House Mafia - One (Your Name)"
+      },
+      {
+        "ytId": "gvaLFPDWtdA",
+        "title": "Laidback Luke - Rocking with the Best"
+      },
+      {
+        "ytId": "r6E3J4GPpjc",
+        "title": "Don Diablo - On My Mind"
+      },
+      {
+        "ytId": "V775PPuBc7Y",
+        "title": "Sidney Samson - Riverside"
+      },
+      {
+        "ytId": "AYzgexJVCkw",
+        "title": "Vato Gonzalez - Push Riddim"
+      },
+      {
+        "ytId": "rHqO02q4b18",
+        "title": "Afrojack - Unstoppable "
+      },
+      {
+        "ytId": "li6_41Fusbw",
+        "title": "Chuckie - Let The Bass Kick"
+      }
+    ],
+    "Breakbeat Hardcore": [
+      {
+        "ytId": "4Fu_uld7SIQ",
+        "title": "M.A.N.I.C. - I'm Coming Hardcore"
+      },
+      {
+        "ytId": "gXCN1DhHTZA",
+        "title": "SL2 - On A Ragga Tip"
+      },
+      {
+        "ytId": "2_bL0hFyslg",
+        "title": "Altern 8 Activ-8 (Come with me)"
+      },
+      {
+        "ytId": "E8v7dRXuzEw",
+        "title": "Acen - Trip II the Moon (Part 1)"
+      },
+      {
+        "ytId": "2koaW18Vm1I",
+        "title": "Phuture Assassins - Future Sound"
+      },
+      {
+        "ytId": "CYns_QBpJG0",
+        "title": "Shut Up And Dance - Raving I'm Raving"
+      },
+      {
+        "ytId": "7dpvLjtT7jI",
+        "title": "RatPack - Searching For My Rizla"
+      },
+      {
+        "ytId": "ns3rmEHfkCI",
+        "title": "Rhythm Foundation - Let The Whole World Know"
+      },
+      {
+        "ytId": "6rALSXnYpmQ",
+        "title": "New Atlantic - I Know"
+      },
+      {
+        "ytId": "WKHKN7odpbY",
+        "title": "Hyper Go Go - Never Let Go (piano mix)"
+      },
+      {
+        "ytId": "0H9jQQVnU2g",
+        "title": "Together - Hardcore Uproar"
+      },
+      {
+        "ytId": "bq4JcPxAdd0",
+        "title": "Pierre Feroldi feat Linda Ray - Movin Now"
+      }
+    ],
+    "Minimal Techno": [
+      {
+        "ytId": "E8PhL_u9Q5Y",
+        "title": "Robert Hood - And Then We Planned Our Escape"
+      },
+      {
+        "ytId": "Nsct-e-HVE0",
+        "title": "Plastikman - Spastik"
+      },
+      {
+        "ytId": "eaVY5Y13sc0",
+        "title": "Basic Channel - Octagon"
+      },
+      {
+        "ytId": "l_RfediFJFQ",
+        "title": "Green Velvet - Flash"
+      },
+      {
+        "ytId": "Xi7MJn7NoTc",
+        "title": "Gas - Klang"
+      },
+      {
+        "ytId": "EoMksOzl-xs",
+        "title": "Fragile / Mike Ink"
+      },
+      {
+        "ytId": "giFk55cBjww",
+        "title": "Ø (Mika Vainio) - Stratostaatti"
+      },
+      {
+        "ytId": "AESZ1I-r44E",
+        "title": "Safety Scissors - Fridgelife"
+      },
+      {
+        "ytId": "nxMaf7NSKBE",
+        "title": "Daniel Bell - Baby Judy"
+      },
+      {
+        "ytId": "zvZjswJ-YY4",
+        "title": "Kenny Larkin - Paranoid"
+      }
+    ],
+    "Oldschool Jungle/DnB": [
+      {
+        "ytId": "lx9-fjlh7Y4",
+        "title": "Goldie - Inner City Life"
+      },
+      {
+        "ytId": "W8Mh7ImxVKY",
+        "title": "Dj Rap - Tibetan Jungle"
+      },
+      {
+        "ytId": "rqAluSHBI3o",
+        "title": "Kemistry & Storm - Signature"
+      },
+      {
+        "ytId": "FZ68IUVYGg0",
+        "title": "Photek - Complex"
+      },
+      {
+        "ytId": "Vdw5OhOPmuM",
+        "title": "Remarc - Drum N' Bass Wise"
+      },
+      {
+        "ytId": "ONa4LKiljr8",
+        "title": "Q Project - Champion Sound"
+      },
+      {
+        "ytId": "1GU9p35eNH4",
+        "title": "Dillinja - Twist 'Em Out"
+      },
+      {
+        "ytId": "Vt39DQGbHTg",
+        "title": "DJ Fabio - Kings of the Jungle VI"
+      },
+      {
+        "ytId": "mL2Bgj-za5k",
+        "title": "M Beat feat General Levy Incredible"
+      },
+      {
+        "ytId": "QL4GQ5H0lkc",
+        "title": "Congo Natty Junglist"
+      },
+      {
+        "ytId": "es3RMEBx0pg",
+        "title": "Shy Fx - Original Nuttah"
+      }
+    ],
+    "Jump Up": [
+      {
+        "ytId": "9XCwBljqsnk",
+        "title": "DJ Aphrodite - King Of The Beats (2015)"
+      },
+      {
+        "ytId": "mkzMHEtYu5Y",
+        "title": "Urban takeover -  Bad ass (urban mix)"
+      },
+      {
+        "ytId": "l2KZoWLot0g",
+        "title": "Super Sharp Shooter - The Ganja Kru"
+      },
+      {
+        "ytId": "O8MlkiGsVMc",
+        "title": "Mulder - Stick Up Kid (Urban Takeover)"
+      },
+      {
+        "ytId": "vXNnJHE3TPc",
+        "title": "Andy C - New Era"
+      },
+      {
+        "ytId": "43Cnk0079iA",
+        "title": "Mampi Swift - Guess Who"
+      },
+      {
+        "ytId": "GQuj6YQ-WX0",
+        "title": "DJ Hazard - It's A Secret"
+      },
+      {
+        "ytId": "G4s7pFHvAI4",
+        "title": "Majistrate - Feel So Good. feat Jessica Luck [Sweet Tooth Recordings]"
+      },
+      {
+        "ytId": "7IsmYk7-b9Q",
+        "title": "Sub Zero - Straight In"
+      },
+      {
+        "ytId": "rPRkYWVinF0",
+        "title": "Chase & Status feat. Takura \"No Problem\""
+      }
+    ],
+    "Trip Hop": [
+      {
+        "ytId": "ZWmrfgj0MZI",
+        "title": "Massive Attack - Unfinished Sympathy"
+      },
+      {
+        "ytId": "PdflxJTFl8w",
+        "title": "DJ Shadow - In/Flux"
+      },
+      {
+        "ytId": "25y3cMC9i94",
+        "title": "Tricky - 'Aftermath' "
+      },
+      {
+        "ytId": "4qQyUi4zfDs",
+        "title": "Portishead - Glory Box"
+      },
+      {
+        "ytId": "--wy8QmLlM8",
+        "title": "Morcheeba - The Sea - Big Calm (1998)"
+      },
+      {
+        "ytId": "2eBZqmL8ehg",
+        "title": "Sneaker Pimps - 6 Underground - Official Video"
+      },
+      {
+        "ytId": "rmWGaKgXnHM",
+        "title": "The Richest Man In Babylon by Thievery Corporation"
+      },
+      {
+        "ytId": "kdQycB5I6C4",
+        "title": "U.N.K.L.E. - Be There"
+      },
+      {
+        "ytId": "_YCGtT_FRYg",
+        "title": "Rob dougan clubbed to death videoclip"
+      }
+    ]
+  }
 }

--- a/src/js/game.js
+++ b/src/js/game.js
@@ -148,32 +148,28 @@ Draw Round
 ========================================================================== */
 
 const drawNewRound = () => new Promise((resolve) => {
-  const draw = () => {
-    // Trow dice
-    const correctIndex = Math.floor(Math.random() * 4)
-    // Draw 4 random tracks
-    const answers = _.sampleSize(genreData.tracks, 4)
-    // Check if draw has unique genres
-    const genres = _.map(answers, 'genre')
-    const isUnique = _.uniq(genres).length === answers.length
-    // If unique draw update gameData and resolve, else draw again
-    if (isUnique) {
-      for (const [index, item] of answers.entries()) {
-        const isCorrectAnswer = index === correctIndex
-        gameData.currentGame.answers.push({
-          genre: item.genre,
-          correct: isCorrectAnswer
-        })
-        if (isCorrectAnswer) {
-          gameData.currentGame.track.info = item
-        }
-      }
-      resolve()
-    } else {
-      draw()
+  // Trow dice
+  const correctIndex = Math.floor(Math.random() * 4)
+  // Draw 4 random genres
+  const genres = _.sampleSize(genreData.genres, 4)
+  // Draw one song from each genre
+  const answers = []
+  for (const genre of genres) {
+    const track = _.sample(genreData.tracks[genre])
+    track.genre = genre
+    answers.push(track)
+  }
+  for (const [index, item] of answers.entries()) {
+    const isCorrectAnswer = index === correctIndex
+    gameData.currentGame.answers.push({
+      genre: item.genre,
+      correct: isCorrectAnswer
+    })
+    if (isCorrectAnswer) {
+      gameData.currentGame.track.info = item
     }
   }
-  draw()
+  resolve()
 })
 
 export default {


### PR DESCRIPTION
While playing the game I noticed some bias in the chosen songs, where common genres would be played often, while the less well known genres would rarely be played.

Looking at the code, I noticed that it's sampling from all tracks and making sure the genres are unique. This means genres with more songs in them like Detroit Techno and Acid House are more likely to be played than Glitch Hop or Dutch House. It's not a huge bias as most genres in the dataset have around 20 songs in them, but if you want to have a more uniform genre distribution, this PR does that.

I restructured `src/data/data.json` to have tracks keyed by genre, and updated `drawNewRound` to sample four genres first, then one track from each genre, which should sample all genres uniformly regardless of how many tracks they contain.

I also fixed a mismatch between the `genres` list and the tracks themselves: the "Trancecore / Acidcore" genre was listed as "Trancecore & Acidcore" in the tracks.